### PR TITLE
Tag 1.0 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When we run `npm publish`, prepublish script of package.json is executed. Script
 + `./dist/creative.js` - Minified creative.js source code
 + `./dist/creative.max.js` - Unminified source code to help in debugging.
 
-[jsDelivr](https://www.jsdelivr.com/) – Open Source CDN is used to serve creative.js file.
+The latest version of the creative.js file is hosted on the AppNexus CDN (https://acdn.adnxs.com).
 
 ## Contributing
 

--- a/src/creative.js
+++ b/src/creative.js
@@ -12,7 +12,8 @@
 import * as utils from './utils';
 import * as environment from './environment';
 
-const pbjs = window.pbjs = (window.pbjs || {});
+// const pbjs = window.pbjs = (window.pbjs || {});
+const ucTag = window.ucTag = {};
 const GOOGLE_IFRAME_HOSTNAME = '//tpc.googlesyndication.com';
 const DEFAULT_CACHE_HOST = 'prebid.adnxs.com';
 const DEFAULT_CACHE_PATH = '/pbc/v1/cache';
@@ -29,18 +30,19 @@ const DEFAULT_CACHE_PATH = '/pbc/v1/cache';
 /**
  * Public render ad function to be used in dfp creative setup
  * @param  {object} doc
- * @param  {string} adId
  * @param  {dataObject} dataObject
  */
-pbjs.renderAd = function(doc, adId, dataObject) {
-  if(environment.isMobileApp(dataObject)) {
-    renderAmpOrMobileAd(dataObject.cacheHost, dataObject.cachePath, dataObject.uuid, dataObject.size, true);
-  } else if (environment.isAmp(dataObject)) {
-    renderAmpOrMobileAd(dataObject.cacheHost, dataObject.cachePath, dataObject.uuid, dataObject.size);
+ucTag.renderAd = function(doc, dataObject) {
+  const auctionData = utils.transformAuctionTargetingData(dataObject);
+
+  if(environment.isMobileApp(auctionData.env)) {
+    renderAmpOrMobileAd(auctionData.cacheHost, auctionData.cachePath, auctionData.uuid, auctionData.size, true);
+  } else if (environment.isAmp(auctionData.uuid)) {
+    renderAmpOrMobileAd(auctionData.cacheHost, auctionData.cachePath, auctionData.uuid, auctionData.size);
   } else if (environment.isCrossDomain()) {
-    renderCrossDomain(adId, dataObject.pubUrl);
+    renderCrossDomain(auctionData.adId, auctionData.adServerDomain, auctionData.pubUrl);
   } else {
-    renderLegacy(doc, adId);
+    renderLegacy(doc, auctionData.adId);
   }
 };
 
@@ -69,11 +71,11 @@ function renderLegacy(doc, adId) {
  * @param {string} adId Id of creative to render
  * @param {string} pubUrl Url of publisher page
  */
-function renderCrossDomain(adId, pubUrl) {
+function renderCrossDomain(adId, pubAdServerDomain, pubUrl) {
   let urlParser = document.createElement('a');
   urlParser.href = pubUrl;
   let publisherDomain = urlParser.protocol + '//' + urlParser.host;
-  let adServerDomain = urlParser.protocol + GOOGLE_IFRAME_HOSTNAME;
+  let adServerDomain = (pubAdServerDomain) ? urlParser.protocol + '//' + pubAdServerDomain : urlParser.protocol + GOOGLE_IFRAME_HOSTNAME;
 
   function renderAd(ev) {
     let key = ev.message ? 'message' : 'data';
@@ -141,6 +143,8 @@ function renderCrossDomain(adId, pubUrl) {
 function getCacheEndpoint(cacheHost, cachePath) {
   let host = (typeof cacheHost === 'undefined' || cacheHost === "") ? DEFAULT_CACHE_HOST : cacheHost;
   let path = (typeof cachePath === 'undefined' || cachePath === "") ? DEFAULT_CACHE_PATH : cachePath;
+
+  // QUESTION - DOES THIS HAVE TO BE SECURE 100%?
   return `https://${host}${path}`;
 }
 

--- a/src/creative.js
+++ b/src/creative.js
@@ -32,16 +32,16 @@ const DEFAULT_CACHE_PATH = '/pbc/v1/cache';
  * @param  {dataObject} dataObject
  */
 ucTag.renderAd = function(doc, dataObject) {
-  const auctionData = utils.transformAuctionTargetingData(dataObject);
+  const targetingData = utils.transformAuctionTargetingData(dataObject);
 
-  if(environment.isMobileApp(auctionData.env)) {
-    renderAmpOrMobileAd(auctionData.cacheHost, auctionData.cachePath, auctionData.uuid, auctionData.size, true);
-  } else if (environment.isAmp(auctionData.uuid)) {
-    renderAmpOrMobileAd(auctionData.cacheHost, auctionData.cachePath, auctionData.uuid, auctionData.size);
+  if(environment.isMobileApp(targetingData.env)) {
+    renderAmpOrMobileAd(targetingData.cacheHost, targetingData.cachePath, targetingData.uuid, targetingData.size, true);
+  } else if (environment.isAmp(targetingData.uuid)) {
+    renderAmpOrMobileAd(targetingData.cacheHost, targetingData.cachePath, targetingData.uuid, targetingData.size);
   } else if (environment.isCrossDomain()) {
-    renderCrossDomain(auctionData.adId, auctionData.adServerDomain, auctionData.pubUrl);
+    renderCrossDomain(targetingData.adId, targetingData.adServerDomain, targetingData.pubUrl);
   } else {
-    renderLegacy(doc, auctionData.adId);
+    renderLegacy(doc, targetingData.adId);
   }
 };
 

--- a/src/creative.js
+++ b/src/creative.js
@@ -12,7 +12,6 @@
 import * as utils from './utils';
 import * as environment from './environment';
 
-// const pbjs = window.pbjs = (window.pbjs || {});
 const ucTag = window.ucTag = {};
 const GOOGLE_IFRAME_HOSTNAME = '//tpc.googlesyndication.com';
 const DEFAULT_CACHE_HOST = 'prebid.adnxs.com';
@@ -144,7 +143,6 @@ function getCacheEndpoint(cacheHost, cachePath) {
   let host = (typeof cacheHost === 'undefined' || cacheHost === "") ? DEFAULT_CACHE_HOST : cacheHost;
   let path = (typeof cachePath === 'undefined' || cachePath === "") ? DEFAULT_CACHE_PATH : cachePath;
 
-  // QUESTION - DOES THIS HAVE TO BE SECURE 100%?
   return `https://${host}${path}`;
 }
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -46,6 +46,7 @@ function isDfp() {
 }
 
 /**
+ * @param {String} uuid key value from auction, contains the cache id of the winning bid stored in prebid cache
  * @returns true if there is an AMP context object
  */
 export function isAmp(uuid) {
@@ -80,8 +81,8 @@ export function isCrossDomain() {
 }
 
 /**
- * Returns true if envrionment is mobile app
- * @param {String} env 
+ * @param {String} env key value from auction, indicates the environment where tag is served
+ * @returns true if env exists and is equal to the string 'mobile-app'
  */
 export function isMobileApp(env) {
   return env && env === 'mobile-app';

--- a/src/environment.js
+++ b/src/environment.js
@@ -48,10 +48,10 @@ function isDfp() {
 /**
  * @returns true if there is an AMP context object
  */
-export function isAmp(dataObject) {
+export function isAmp(uuid) {
   // TODO Use amp context once it is available in cross domain
   // https://github.com/ampproject/amphtml/issues/6829
-  return typeof dataObject.uuid === 'string' && dataObject.uuid != "" && isCrossDomain();
+  return typeof uuid === 'string' && uuid !== "" && isCrossDomain();
 }
 
 /**
@@ -81,8 +81,8 @@ export function isCrossDomain() {
 
 /**
  * Returns true if envrionment is mobile app
- * @param {Object} dataObject 
+ * @param {String} env 
  */
-export function isMobileApp(dataObject) {
-  return dataObject.env && dataObject.env === 'mobile-app';
+export function isMobileApp(env) {
+  return env && env === 'mobile-app';
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -136,3 +136,37 @@ export function triggerBurl(url) {
   img.src = url;
 };
 
+export function transformAuctionTargetingData(dataObject) {
+  const auctionKeyMap = {
+    hb_adid: 'adId',
+    hb_cache_host: 'cacheHost',
+    hb_cache_path: 'cachePath',
+    hb_cache_id: 'uuid',
+    hb_format: 'mediaType',
+    hb_env: 'env',
+    hb_size: 'size'
+  };
+
+  let cleanedDataObject = {};
+
+  // set keys defined in targetingMap object (if it's defined)
+  const tarMap = dataObject.targetingMap || {};
+  const tarMapKeys = Object.keys(tarMap);
+  if (tarMapKeys.length > 0) {
+    tarMapKeys.forEach(function(key) {
+      if (Array.isArray(tarMap[key]) && tarMap[key].length > 0) {
+        let internalKey = auctionKeyMap[key];
+        cleanedDataObject[internalKey] = tarMap[key][0];
+      }
+    });
+  }
+
+  // set keys not in targetingMap and/or the keys setup within a non-DFP adserver
+  Object.keys(dataObject).forEach(function (key) {
+    if (key !== 'targetingMap' && typeof dataObject[key] === 'string') {
+      cleanedDataObject[key] = dataObject[key];
+    }
+  });
+
+  return cleanedDataObject;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -147,7 +147,7 @@ export function transformAuctionTargetingData(dataObject) {
     hb_size: 'size'
   };
 
-  let cleanedDataObject = {};
+  let auctionData = {};
 
   // set keys defined in targetingMap object (if it's defined)
   const tarMap = dataObject.targetingMap || {};
@@ -156,7 +156,7 @@ export function transformAuctionTargetingData(dataObject) {
     tarMapKeys.forEach(function(key) {
       if (Array.isArray(tarMap[key]) && tarMap[key].length > 0) {
         let internalKey = auctionKeyMap[key];
-        cleanedDataObject[internalKey] = tarMap[key][0];
+        auctionData[internalKey] = tarMap[key][0];
       }
     });
   }
@@ -164,9 +164,9 @@ export function transformAuctionTargetingData(dataObject) {
   // set keys not in targetingMap and/or the keys setup within a non-DFP adserver
   Object.keys(dataObject).forEach(function (key) {
     if (key !== 'targetingMap' && typeof dataObject[key] === 'string') {
-      cleanedDataObject[key] = dataObject[key];
+      auctionData[key] = dataObject[key];
     }
   });
 
-  return cleanedDataObject;
+  return auctionData;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -155,7 +155,7 @@ export function transformAuctionTargetingData(dataObject) {
   if (tarMapKeys.length > 0) {
     tarMapKeys.forEach(function(key) {
       if (Array.isArray(tarMap[key]) && tarMap[key].length > 0) {
-        let internalKey = auctionKeyMap[key];
+        let internalKey = auctionKeyMap[key] || key;
         auctionData[internalKey] = tarMap[key][0];
       }
     });

--- a/template/amp/dfp-creative.html
+++ b/template/amp/dfp-creative.html
@@ -1,4 +1,4 @@
-<script src = "https://cdn.jsdelivr.net/npm/prebid-universal-creative@0.4.0/dist/creative.js"></script>
+<script src = "https://acdn.adnxs.com/prebid/universal-creative/creative.js"></script>
 <script>
   var ucTagData = {};
   ucTagData.adServerDomain = "";

--- a/template/amp/dfp-creative.html
+++ b/template/amp/dfp-creative.html
@@ -4,6 +4,9 @@
   ucTagData.adServerDomain = "";
   ucTagData.pubUrl = "%%PATTERN:url%%";
 
+  // if DFP, use this param
+  ucTagData.targetingMap = %%PATTERN:TARGETINGMAP%%;
+
   // if not DFP, use these params
   ucTagData.adId = "%%PATTERN:hb_adid%%";
   ucTagData.cacheHost = "%%PATTERN:hb_cache_host%%";
@@ -12,9 +15,6 @@
   ucTagData.mediaType = "%%PATTERN:hb_format%%";
   ucTagData.env = "%%PATTERN:hb_env%%";
   ucTagData.size = "%%PATTERN:hb_size%%";
-
-  // if DFP, use this param
-  ucTagData.targetingMap = %%PATTERN:TARGETINGMAP%%;
 
   try {
     ucTag.renderAd(document, ucTagData);

--- a/template/amp/dfp-creative.html
+++ b/template/amp/dfp-creative.html
@@ -1,17 +1,24 @@
 <script src = "https://cdn.jsdelivr.net/npm/prebid-universal-creative@0.4.0/dist/creative.js"></script>
 <script>
-var adId = "%%PATTERN:hb_adid%%";
-var cacheHost = "%%PATTERN:hb_cache_host%%";
-var cachePath = "%%PATTERN:hb_cache_path%%";
-var uuid = "%%PATTERN:hb_cache_id%%";
-var mediaType = "%%PATTERN:hb_format%%";
-var pubUrl = "%%PATTERN:url%%";
-var env = "%%PATTERN:hb_env%%";
-var size = "%%PATTERN:hb_size%%";
+  var ucTagData = {};
+  ucTagData.adServerDomain = "";
+  ucTagData.pubUrl = "%%PATTERN:url%%";
 
-try {    
-    pbjs.renderAd(document, adId, {cacheHost: cacheHost, cachePath: cachePath, uuid: uuid, mediaType: mediaType, pubUrl: pubUrl, env: env, size: size});
-} catch(e) {
+  // if not DFP, use these params
+  ucTagData.adId = "%%PATTERN:hb_adid%%";
+  ucTagData.cacheHost = "%%PATTERN:hb_cache_host%%";
+  ucTagData.cachePath = "%%PATTERN:hb_cache_path%%";
+  ucTagData.uuid = "%%PATTERN:hb_cache_id%%";
+  ucTagData.mediaType = "%%PATTERN:hb_format%%";
+  ucTagData.env = "%%PATTERN:hb_env%%";
+  ucTagData.size = "%%PATTERN:hb_size%%";
+
+  // if DFP, use this param
+  ucTagData.targetingMap = %%PATTERN:TARGETINGMAP%%;
+
+  try {
+    ucTag.renderAd(document, ucTagData);
+  } catch (e) {
     console.log(e);
-}
+  }
 </script>


### PR DESCRIPTION
The following changes are included:
- add support for `adServerDomain` param in tag for safeframe environments.  This allows the publisher to set a value for the safeframe domain (previously used hard-coded DFP safeframe domain)
- add support to use DFP `%%PATTERN:TARGETINGMAP%%` macro to dynamically pass in the auction keys to the universal creative rendering function.  The macro provides an object map with each auction key used for that DFP creative; the values for each key are stored in a single array string.
- reworked the tag structure/API to support the above TARGETINGMAP approach and the old approach (for non-DFP) ad-servers.  See example in `dfp-example.html` file for reference.
    - renamed global object `pbjs` to `ucTag` when calling the `renderAd` function