### PR TITLE
fix for targeting keys bug

### DIFF
--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -1,6 +1,6 @@
 import * as utils from './utils';
 
-const GOOGLE_IFRAME_HOSTNAME = '//tpc.googlesyndication.com';
+const GOOGLE_IFRAME_HOSTNAME = 'tpc.googlesyndication.com';
 const DEFAULT_CACHE_HOST = 'prebid.adnxs.com';
 const DEFAULT_CACHE_PATH = '/pbc/v1/cache';
 
@@ -64,10 +64,11 @@ export function newRenderingManager(win, environment) {
    * @param {string} pubAdServerDomain publisher adserver domain name
    * @param {string} pubUrl Url of publisher page
    */
-  function renderCrossDomain(adId, pubAdServerDomain, pubUrl) {
+  function renderCrossDomain(adId, pubAdServerDomain = '', pubUrl) {
     let parsedUrl = utils.parseUrl(pubUrl);
-    let publisherDomain = parsedUrl.protocol + '//' + parsedUrl.host;
-    let adServerDomain = (pubAdServerDomain) ? parsedUrl.protocol + '//' + pubAdServerDomain : parsedUrl.protocol + GOOGLE_IFRAME_HOSTNAME;
+    let publisherDomain = parsedUrl.protocol + '://' + parsedUrl.host;
+    let adServerDomain = (pubAdServerDomain !== '') ? pubAdServerDomain : GOOGLE_IFRAME_HOSTNAME;
+    let fullAdServerDomain = parsedUrl.protocol + '://' + adServerDomain;
 
     function renderAd(ev) {
       let key = ev.message ? 'message' : 'data';
@@ -114,7 +115,7 @@ export function newRenderingManager(win, environment) {
       let message = JSON.stringify({
         message: 'Prebid Request',
         adId: adId,
-        adServerDomain: adServerDomain
+        adServerDomain: fullAdServerDomain
       });
       win.parent.postMessage(message, publisherDomain);
     }
@@ -147,7 +148,7 @@ export function newRenderingManager(win, environment) {
    * @param {string} size size of the creative
    * @param {Bool} isMobileApp flag to detect mobile app
    */
-  function renderAmpOrMobileAd(cacheHost, cachePath, uuid, size, isMobileApp) {
+  function renderAmpOrMobileAd(cacheHost, cachePath, uuid = '', size, isMobileApp) {
     // For MoPub, creative is stored in localStorage via SDK.
     let search = 'Prebid_';
     if(uuid.substr(0, search.length) === search) {

--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -67,12 +67,8 @@ export function newRenderingManager(win, environment) {
   function renderCrossDomain(adId, pubAdServerDomain = '', pubUrl) {
     let parsedUrl = utils.parseUrl(pubUrl);
     let publisherDomain = parsedUrl.protocol + '://' + parsedUrl.host;
-<<<<<<< HEAD
     let adServerDomain = (pubAdServerDomain !== '') ? pubAdServerDomain : GOOGLE_IFRAME_HOSTNAME;
     let fullAdServerDomain = parsedUrl.protocol + '://' + adServerDomain;
-=======
-    let adServerDomain = (pubAdServerDomain) ? parsedUrl.protocol + '://' + pubAdServerDomain : parsedUrl.protocol + '://' + GOOGLE_IFRAME_HOSTNAME;
->>>>>>> master
 
     function renderAd(ev) {
       let key = ev.message ? 'message' : 'data';

--- a/src/utils.js
+++ b/src/utils.js
@@ -163,7 +163,7 @@ export function transformAuctionTargetingData(dataObject) {
 
   // set keys not in targetingMap and/or the keys setup within a non-DFP adserver
   Object.keys(dataObject).forEach(function (key) {
-    if (key !== 'targetingMap' && typeof dataObject[key] === 'string') {
+    if (key !== 'targetingMap' && typeof dataObject[key] === 'string' && dataObject[key] !== '') {
       auctionData[key] = dataObject[key];
     }
   });

--- a/test/spec/renderingManager_spec.js
+++ b/test/spec/renderingManager_spec.js
@@ -3,6 +3,7 @@ import * as utils from 'src/utils';
 import { expect } from 'chai';
 import { mocks } from 'test/helpers/mocks';
 import { merge } from 'lodash';
+import { debug } from 'util';
 
 const renderingMocks = {
   messages: [],
@@ -198,9 +199,8 @@ describe('renderingManager', function() {
     });
 
     it('should render cross domain creative', function() {
-      debugger;
       parseStub.returns({
-        protocol: 'http:',
+        protocol: 'http',
         host: 'example.com'
       });
       iframeStub.returns(mockIframe);

--- a/test/spec/renderingManager_spec.js
+++ b/test/spec/renderingManager_spec.js
@@ -3,7 +3,6 @@ import * as utils from 'src/utils';
 import { expect } from 'chai';
 import { mocks } from 'test/helpers/mocks';
 import { merge } from 'lodash';
-import { debug } from 'util';
 
 const renderingMocks = {
   messages: [],

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -41,4 +41,46 @@ describe('utils', function() {
       env: 'mobile-app'
     });
   });
+
+  it('should ignore keys set to empty strings', function () {
+    let ucTagData = {
+      targetingMap: {
+        hb_adid: ['123abc'],
+        hb_format: ['banner'],
+        hb_size: ['300x250']
+      },
+      adServerDomain: '',
+      pubUrl: 'http://www.test.com',
+      adId: ''
+    };
+
+    let auctionData = utils.transformAuctionTargetingData(ucTagData);
+    expect(auctionData).to.deep.equal({
+      adId: '123abc',
+      mediaType: 'banner',
+      size: '300x250',
+      pubUrl: 'http://www.test.com'
+    });
+  });
+
+  it('should preserve extra keys found in targetingMap and transform known keys', function () {
+    let ucTagData = {
+      targetingMap: {
+        hb_adid: ['123abc'],
+        hb_adid_appnexus: ['123abc'],
+        hb_format: ['banner'],
+        hb_size: ['300x250'],
+        hb_bidder: ['appnexus']
+      }
+    };
+
+    let auctionData = utils.transformAuctionTargetingData(ucTagData);
+    expect(auctionData).to.deep.equal({
+      adId: '123abc',
+      hb_adid_appnexus: '123abc',
+      mediaType: 'banner',
+      size: '300x250',
+      hb_bidder: 'appnexus'
+    });
+  });
 });


### PR DESCRIPTION
**Bug Summary**
If someone set a property in the `ucTagData` object to an empty string, it would use that value even if it had a proper value in the `ucTagData.targetingMap`.  

For example (contrived in presentation to demonstrate problem):
```
ucTagData.targetingMap.hb_adid = '123abc';
ucTagData.adId = '';
```
This would result in the return object's `auctionData.adId` to be set to `''` instead of `123abc`, which would cause the rendering logic later to fail due to a missing `adId`.

**Cause**
Bad logic in function.

**Fix**
Any keys that are set outside the `targetingMap` that have an empty string are ignored.  This will preserve any previously set keys from the `targetingMap`.  

This change also has a separate benefit in that we're standardizing the appearance of the return object from the `utils.transformAuctionTargetingData` function.  

To illustrate, take the `cachePath` property.  
- In a banner tag for DFP (using `targetingMap`), this key would not be part of the `targetingMap` - so it would be an `undefined` key in the return object.
- In a banner tag for non-DFP (where we set the `ucTagData.cachePath` property), this would be set to an empty string (due to how the token would likely resolve).  In turn we would have an empty string in the return object for the same property.

When the logic in the `renderingManager.js` file's `renderAd` function would have to read this return object - it would have to handle either an `undefined` or an empty string.

With this fix, it will always be `undefined`.

_Note_ - because values are `undefined` instead of empty strings, I set a default value in the argument list for some of the other functions when they are expecting a string type value.  This is to prevent undefined exceptions in certain use-cases.