### PR TITLE
add decode step in parseUrl function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -173,7 +173,8 @@ export function transformAuctionTargetingData(dataObject) {
 
 export function parseUrl(url) {
   let parsed = document.createElement('a');
-  parsed.href = url;
+
+  parsed.href = decodeURIComponent(url);
   
   return {
     href: parsed.href,

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1,86 +1,105 @@
 import { expect } from 'chai';
 import * as utils from 'src/utils';
 
-describe('utils', function() {
-  it('should transform non dfp arguments', function() {
-    let ucTagData = {
-      cacheHost: 'example.com',
-      cachePath: '/path',
-      uuid: '123',
-      size: '300x250'
-    };
-    let auctionData = utils.transformAuctionTargetingData(ucTagData);
-    expect(auctionData).to.deep.equal({
-      cacheHost: 'example.com',
-      cachePath: '/path',
-      uuid: '123',
-      size: '300x250'
+describe('utils', function () {
+  describe('transformAuctionTargetingData', function () {
+    it('should transform non dfp arguments', function () {
+      let ucTagData = {
+        cacheHost: 'example.com',
+        cachePath: '/path',
+        uuid: '123',
+        size: '300x250'
+      };
+      let auctionData = utils.transformAuctionTargetingData(ucTagData);
+      expect(auctionData).to.deep.equal({
+        cacheHost: 'example.com',
+        cachePath: '/path',
+        uuid: '123',
+        size: '300x250'
+      });
+    });
+
+    it('should transform targeting map', function () {
+      let ucTagData = {
+        targetingMap: {
+          hb_adid: ['123'],
+          hb_cache_host: ['example.com'],
+          hb_cache_path: ['/path'],
+          hb_cache_id: ['123'],
+          hb_size: ['300x250'],
+          hb_format: ['banner'],
+          hb_env: ['mobile-app']
+        }
+      };
+      let auctionData = utils.transformAuctionTargetingData(ucTagData);
+      expect(auctionData).to.deep.equal({
+        adId: '123',
+        cacheHost: 'example.com',
+        cachePath: '/path',
+        uuid: '123',
+        size: '300x250',
+        mediaType: 'banner',
+        env: 'mobile-app'
+      });
+    });
+
+    it('should ignore keys set to empty strings', function () {
+      let ucTagData = {
+        targetingMap: {
+          hb_adid: ['123abc'],
+          hb_format: ['banner'],
+          hb_size: ['300x250']
+        },
+        adServerDomain: '',
+        pubUrl: 'http://www.test.com',
+        adId: ''
+      };
+
+      let auctionData = utils.transformAuctionTargetingData(ucTagData);
+      expect(auctionData).to.deep.equal({
+        adId: '123abc',
+        mediaType: 'banner',
+        size: '300x250',
+        pubUrl: 'http://www.test.com'
+      });
+    });
+
+    it('should preserve extra keys found in targetingMap and transform known keys', function () {
+      let ucTagData = {
+        targetingMap: {
+          hb_adid: ['123abc'],
+          hb_adid_appnexus: ['123abc'],
+          hb_format: ['banner'],
+          hb_size: ['300x250'],
+          hb_bidder: ['appnexus']
+        }
+      };
+
+      let auctionData = utils.transformAuctionTargetingData(ucTagData);
+      expect(auctionData).to.deep.equal({
+        adId: '123abc',
+        hb_adid_appnexus: '123abc',
+        mediaType: 'banner',
+        size: '300x250',
+        hb_bidder: 'appnexus'
+      });
     });
   });
 
-  it('should transform targeting map', function() {
-    let ucTagData = {
-      targetingMap: {
-        hb_adid: ['123'],
-        hb_cache_host: ['example.com'],
-        hb_cache_path: ['/path'],
-        hb_cache_id: ['123'],
-        hb_size: ['300x250'],
-        hb_format: ['banner'],
-        hb_env: ['mobile-app']
-      }
-    };
-    let auctionData = utils.transformAuctionTargetingData(ucTagData);
-    expect(auctionData).to.deep.equal({
-      adId: '123', 
-      cacheHost: 'example.com', 
-      cachePath: '/path', 
-      uuid: '123', 
-      size: '300x250', 
-      mediaType: 'banner', 
-      env: 'mobile-app'
-    });
-  });
-
-  it('should ignore keys set to empty strings', function () {
-    let ucTagData = {
-      targetingMap: {
-        hb_adid: ['123abc'],
-        hb_format: ['banner'],
-        hb_size: ['300x250']
-      },
-      adServerDomain: '',
-      pubUrl: 'http://www.test.com',
-      adId: ''
-    };
-
-    let auctionData = utils.transformAuctionTargetingData(ucTagData);
-    expect(auctionData).to.deep.equal({
-      adId: '123abc',
-      mediaType: 'banner',
-      size: '300x250',
-      pubUrl: 'http://www.test.com'
-    });
-  });
-
-  it('should preserve extra keys found in targetingMap and transform known keys', function () {
-    let ucTagData = {
-      targetingMap: {
-        hb_adid: ['123abc'],
-        hb_adid_appnexus: ['123abc'],
-        hb_format: ['banner'],
-        hb_size: ['300x250'],
-        hb_bidder: ['appnexus']
-      }
-    };
-
-    let auctionData = utils.transformAuctionTargetingData(ucTagData);
-    expect(auctionData).to.deep.equal({
-      adId: '123abc',
-      hb_adid_appnexus: '123abc',
-      mediaType: 'banner',
-      size: '300x250',
-      hb_bidder: 'appnexus'
+  describe('parseUrl', function() {
+    it('should properly parse an encoded url', function() {
+      let encUrl = 'http%3A%2F%2Fjsnellbaker.devnxs.net%2Fast_uc_sf_test.html%3Fpbjs_debug%3Dtrue%26ast_debug%3Dtrue';
+      
+      let result = utils.parseUrl(encUrl);
+      expect(result).to.deep.equal({
+        href: 'http://jsnellbaker.devnxs.net/ast_uc_sf_test.html?pbjs_debug=true&ast_debug=true',
+        protocol: 'http',
+        hostname: 'jsnellbaker.devnxs.net',
+        port: 0,
+        pathname: '/ast_uc_sf_test.html',
+        hash: '',
+        host: 'jsnellbaker.devnxs.net'
+      });
     });
   });
 });

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -91,15 +91,15 @@ describe('utils', function () {
       let encUrl = 'http%3A%2F%2Fjsnellbaker.devnxs.net%2Fast_uc_sf_test.html%3Fpbjs_debug%3Dtrue%26ast_debug%3Dtrue';
       
       let result = utils.parseUrl(encUrl);
-      expect(result).to.deep.equal({
-        href: 'http://jsnellbaker.devnxs.net/ast_uc_sf_test.html?pbjs_debug=true&ast_debug=true',
-        protocol: 'http',
-        hostname: 'jsnellbaker.devnxs.net',
-        port: 0,
-        pathname: '/ast_uc_sf_test.html',
-        hash: '',
-        host: 'jsnellbaker.devnxs.net'
-      });
+      
+      expect(result).to.be.an('object');
+      expect(result.href).to.exist.and.to.equal('http://jsnellbaker.devnxs.net/ast_uc_sf_test.html?pbjs_debug=true&ast_debug=true');
+      expect(result.protocol).to.exist.and.to.equal('http');
+      expect(result.hostname).to.exist.and.to.equal('jsnellbaker.devnxs.net');
+      expect(result.port).to.exist.and.that.is.oneOf([0, 80]);
+      expect(result.pathname).to.exist.and.to.equal('/ast_uc_sf_test.html');
+      expect(result.hash).to.exist.and.to.equal('');
+      expect(result.host).to.exist.and.that.is.oneOf(['jsnellbaker.devnxs.net','jsnellbaker.devnxs.net:80']);
     });
   });
 });


### PR DESCRIPTION
Adding a step to the `utils.parseUrl` function to first decode the incoming URL string to ensure it's properly parsed out.  

Observed a bug when the UC tag is nested in an iframe and you pass an encoded URL string to the function, the current method will merely append the incoming URL to the URL of the containing iframe.  This in turn provides the incorrect return value (which is based on the iframe's URL instead of the encoded URL).

This fix should address that scenario.  Further this fix does not impact URLs when they're already decoded.