### PR TITLE
refactor transformAuctionTargetingData and add support for new macro

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -136,7 +136,9 @@ export function triggerBurl(url) {
   img.src = url;
 };
 
-export function transformAuctionTargetingData(dataObject) {
+export function transformAuctionTargetingData(tagData) {
+  // this map object translates the Prebid.js auction keys to their equivalent Prebid Universal Creative keys
+  // when the publisher uses their adserver's generic macro that provides all targeting keys (ie tagData.targetingMap), we need to convert the keys
   const auctionKeyMap = {
     hb_adid: 'adId',
     hb_cache_host: 'cacheHost',
@@ -147,24 +149,85 @@ export function transformAuctionTargetingData(dataObject) {
     hb_size: 'size'
   };
 
-  let auctionData = {};
-
-  // set keys defined in targetingMap object (if it's defined)
-  const tarMap = dataObject.targetingMap || {};
-  const tarMapKeys = Object.keys(tarMap);
-  if (tarMapKeys.length > 0) {
-    tarMapKeys.forEach(function(key) {
-      if (Array.isArray(tarMap[key]) && tarMap[key].length > 0) {
-        let internalKey = auctionKeyMap[key] || key;
-        auctionData[internalKey] = tarMap[key][0];
-      }
-    });
+  /**
+   * Determine if the supplied property of the tagData object exists and is populated with its own values/properties according to its type
+   * @param {string} paramName name of the property to check (eg tagData.targetingMap)
+   * @returns true/false
+   */
+  function isMacroPresent(paramName) {
+    return !!(
+      tagData[paramName] && (
+        (isPlainObject(tagData[paramName]) && Object.keys(tagData[paramName]).length > 0) || 
+        (isStr(tagData[paramName]) && tagData[paramName] !== '')
+      )
+    );
   }
 
-  // set keys not in targetingMap and/or the keys setup within a non-DFP adserver
-  Object.keys(dataObject).forEach(function (key) {
-    if (key !== 'targetingMap' && typeof dataObject[key] === 'string' && dataObject[key] !== '') {
-      auctionData[key] = dataObject[key];
+  /**
+   * Converts the specifically formatted object of keypairs to a more generalized structure
+   * It specifically extracts the keyvalue from an array and stores it as a normal string
+   * @param {object} tarMap object of keys with the keyvalue stored in an array; eg {"hb_adid":["26566ee8c7f251"], ...}
+   * @returns {object} result is an object map like the following: {"hb_cache_id":"123456", "other_key":"other_value", ...}
+   */
+  function convertTargetingMapToNormalMap(tarMap) {
+    let newTarMap = {};
+
+    Object.keys(tarMap).forEach(function(key) {
+      if (Array.isArray(tarMap[key]) && tarMap[key].length > 0) {
+        newTarMap[key] = tarMap[key][0];
+      }
+    });
+    return newTarMap;
+  }
+
+  /**
+   * Converts a specifically formatted string of keypairs to a specifically formatted object map
+   * @param {String} keywordsStr string of keypairs; eg "hb_cache_id:123456,other_key:other_value"
+   * @returns {object} result is an object map like the following: {"hb_cache_id":"123456", "other_key":"other_value", ...}
+   */
+  function convertKeyPairStringToMap(keywordsStr) {
+    let keywordsMap = {};
+    const keywordsArr = keywordsStr.split(',');
+    
+    if (keywordsArr.length > 0) {
+      keywordsArr.forEach(function(keyPairStr) {
+        let keyPairArr = keyPairStr.split(':');
+        if (keyPairArr.length === 2) {
+          let k = keyPairArr[0];
+          let v = keyPairArr[1];
+          keywordsMap[k] = v;
+        }
+      });
+    }
+    return keywordsMap;
+  }
+  
+  /**
+   * Rename key if it's part of the auctionKeyMap object; if not, leave key as is
+   * Store the resultant keypair in the auctionData object for later use in renderingManager.renderAd()
+   * @param {object} adServerKeyMap incoming object map of the auction keys from the UC tag; eg {'key1':'value1', 'key2':'value2', ...}
+   */
+  function renameKnownAuctionKeys(adServerKeyMap) {
+    Object.keys(adServerKeyMap).forEach(function(key) {
+      let internalKey = auctionKeyMap[key] || key;
+      auctionData[internalKey] = adServerKeyMap[key];
+    }); 
+  }
+
+  let auctionData = {};
+  let formattedKeyMap = {};
+  
+  if (isMacroPresent('targetingMap')) {
+    formattedKeyMap = convertTargetingMapToNormalMap(tagData.targetingMap);
+  } else if (isMacroPresent('targetingKeywords')) {
+    formattedKeyMap = convertKeyPairStringToMap(tagData.targetingKeywords);
+  }
+  renameKnownAuctionKeys(formattedKeyMap);
+
+  // set keys not in defined map macros (eg targetingMap) and/or the keys setup within a non-DFP adserver
+  Object.keys(tagData).forEach(function (key) {
+    if (key !== 'targetingMap' && key !== 'targetingKeywords' && isStr(tagData[key]) && tagData[key] !== '') {
+      auctionData[key] = tagData[key];
     }
   });
 
@@ -186,3 +249,15 @@ export function parseUrl(url) {
     host: parsed.host || window.location.host
   };
 }
+
+function isA(object, _t) {
+  return toString.call(object) === '[object ' + _t + ']';
+};
+
+function isPlainObject(object) {
+  return isA(object, 'Object');
+}
+
+function isStr(object) {
+  return isA(object, 'String');
+};

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -54,7 +54,6 @@ describe('utils', function () {
         pubUrl: 'http://www.test.com',
         adId: ''
       };
-
       let auctionData = utils.transformAuctionTargetingData(ucTagData);
       expect(auctionData).to.deep.equal({
         adId: '123abc',
@@ -74,7 +73,6 @@ describe('utils', function () {
           hb_bidder: ['appnexus']
         }
       };
-
       let auctionData = utils.transformAuctionTargetingData(ucTagData);
       expect(auctionData).to.deep.equal({
         adId: '123abc',
@@ -83,6 +81,29 @@ describe('utils', function () {
         size: '300x250',
         hb_bidder: 'appnexus'
       });
+    });
+
+    it('should transform data from targetingKeywords param properly', function() {
+      let ucTagData = {
+        targetingKeywords: "hb_adid:123abc,hb_adid_appnexus:123abc,hb_format:banner,hb_size:300x250,hb_bidder:appnexus,test"
+      };
+      let auctionData = utils.transformAuctionTargetingData(ucTagData);
+      expect(auctionData).to.deep.equal({
+        adId: '123abc',
+        hb_adid_appnexus: '123abc',
+        mediaType: 'banner',
+        size: '300x250',
+        hb_bidder: 'appnexus'
+      });
+
+      ucTagData = {
+        targetingKeywords: '',
+        pubUrl: 'http://www.test.com'
+      };
+      auctionData = utils.transformAuctionTargetingData(ucTagData);
+      expect(auctionData).to.deep.equal({
+        pubUrl: 'http://www.test.com'
+      })
     });
   });
 


### PR DESCRIPTION
Added support in the `utils.transformAuctionTargetingData` function to handle a new keyword map type macro for the Mopub adserver (for Prebid Mobile).

The new macro (named %%KEYWORDS%% in their system) returns a string delimited list of all keywords that were included in the incoming ad call.  Below is a basic copy of the syntax:
`hb_cache_id:123456,other_key:other_value`

This string is converted to an object map of the keypairs and then is processed in the overall function.

In lieu of this new logic, I also heavily refactored the overall function to better support any potential new macros of this sort down the road.