### PR TITLE
add the port variable back into gulp webserver config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,6 +101,7 @@ gulp.task('connect', () => {
   return gulp.src(".").
     pipe(webserver({
       livereload: true,
+      port,
       directoryListing: true,
       open: true
     }));


### PR DESCRIPTION
This PR just adds the `port` variable back into the webserver config so that the locally hosted server (ie when using `gulp serve`) is ran on that port.