### PR TITLE
Replace native placeholders with asset values

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,16 +9,19 @@ const creative = require('./package.json');
 const uglify = require('gulp-uglify');
 const clean = require('gulp-clean');
 const webpackStream = require('webpack-stream');
+const webpack = require('webpack');
 const webpackConfig = require('./webpack.conf');
 const inject = require('gulp-inject');
 const rename = require('gulp-rename');
 const KarmaServer = require('karma').Server;
+const opens = require('open');
 const karmaConfMaker = require('./karma.conf.maker');
 const execa = require('execa');
 const path = require('path');
 
 const dateString = 'Updated : ' + (new Date()).toISOString().substring(0, 10);
 const banner = '/* <%= creative.name %> v<%= creative.version %>\n' + dateString + ' */\n';
+const port = 9990;
 
 gulp.task('serve', ['clean', 'test', 'build-dev', 'build-native-dev', 'build-cookie-sync', 'connect', 'watch']);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,21 +9,18 @@ const creative = require('./package.json');
 const uglify = require('gulp-uglify');
 const clean = require('gulp-clean');
 const webpackStream = require('webpack-stream');
-const webpack = require('webpack');
 const webpackConfig = require('./webpack.conf');
 const inject = require('gulp-inject');
 const rename = require('gulp-rename');
 const KarmaServer = require('karma').Server;
-const opens = require('open');
 const karmaConfMaker = require('./karma.conf.maker');
 const execa = require('execa');
 const path = require('path');
 
 const dateString = 'Updated : ' + (new Date()).toISOString().substring(0, 10);
 const banner = '/* <%= creative.name %> v<%= creative.version %>\n' + dateString + ' */\n';
-const port = 9990;
 
-gulp.task('serve', ['clean', 'test', 'build-dev', 'build-native-dev', 'build-cookie-sync', 'connect']);
+gulp.task('serve', ['clean', 'test', 'build-dev', 'build-native-dev', 'build-cookie-sync', 'connect', 'watch']);
 
 gulp.task('build', ['build-prod', 'build-cookie-sync', 'build-native']);
 
@@ -106,6 +103,13 @@ gulp.task('connect', () => {
       open: true,
       https: argv.https
     }));
+});
+
+gulp.task('watch', () => {
+  gulp.watch(
+    ['src/**/*.js', 'test/**/*.js'],
+    ['clean', 'test', 'build-dev', 'build-native-dev', 'build-cookie-sync']
+  );
 });
 
 // Run the unit tests.

--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -33,7 +33,7 @@ export function newNativeAssetManager(win) {
    * fires a callback after the native html is updated.
    */
   function loadAssets(adId, cb) {
-    const placeholders = scranForPlaceholders(adId);
+    const placeholders = scanForPlaceholders(adId);
 
     if (placeholders.length > 0) {
       callback = cb;
@@ -44,7 +44,7 @@ export function newNativeAssetManager(win) {
   /*
    * Searches the DOM for placeholder values sent in by Prebid Native
    */
-  function scranForPlaceholders(adId) {
+  function scanForPlaceholders(adId) {
     let placeholders = [];
 
     Object.keys(NATIVE_KEYS).forEach(key => {

--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -1,0 +1,127 @@
+/**
+ *
+ */
+
+const NATIVE_KEYS = {
+  title: 'hb_native_title',
+  body: 'hb_native_body',
+  body2: 'hb_native_body2',
+  privacyLink: 'hb_native_privacy',
+  sponsoredBy: 'hb_native_brand',
+  image: 'hb_native_image',
+  icon: 'hb_native_icon',
+  clickUrl: 'hb_native_linkurl',
+  displayUrl: 'hb_native_displayurl',
+  cta: 'hb_native_cta',
+  rating: 'hb_native_rating',
+  address: 'hb_native_address',
+  downloads: 'hb_native_downloads',
+  likes: 'hb_native_likes',
+  phone: 'hb_native_phone',
+  price: 'hb_native_price',
+  salePrice: 'hb_native_saleprice',
+};
+
+export function newNativeAssetManager(win) {
+  let errorCount = 0;
+
+  /**
+   *
+   */
+  function scanForPlaceholders(adId) {
+    console.log('scanning for placeholders...', adId);
+
+    // const placeholders = getPlaceholders();
+
+    // if (placeholders.length > 0) {
+    //   console.log(`Placeholders found!`, placeholders);
+    //   getAssets(placeholders);
+    // }
+  }
+
+  /**
+   *
+   */
+  function getPlaceholders() {
+    console.log('Finding native placeholders:');
+
+    let placeholders = [];
+
+    Object.keys(NATIVE_KEYS).forEach(key => {
+      const value = NATIVE_KEYS[key];
+      const placeholder = `${value}:`;
+      const adIdLength = 14;
+
+      const placeholderIndex = win.document.body.innerHTML.indexOf(placeholder);
+
+      if (~placeholderIndex) {
+        const placeholderWithAdId = win.document.body.innerHTML.slice(
+          placeholderIndex,
+          placeholderIndex + placeholder.length + adIdLength
+        );
+
+        placeholders.push(placeholderWithAdId);
+      }
+    });
+
+    return placeholders;
+  }
+
+  /**
+   *
+   */
+  function getAssets(placeholders) {
+    win.addEventListener('message', replaceListener, false);
+
+    const requestedAssets = placeholders.map(placeholder => placeholder.split(':')[0]);
+    const adId = placeholders[0].split(':')[1];
+
+    const message = {
+      message: 'Prebid Native',
+      action: 'requestAssets',
+      adId,
+      assets: requestedAssets,
+    };
+
+    win.parent.postMessage(JSON.stringify(message), '*');
+  }
+
+  /**
+   *
+   */
+  function replaceListener(event) {
+    var data = {};
+
+    try {
+      data = JSON.parse(event.data);
+    } catch (e) {
+      if (errorCount++ > 10) {
+        win.removeEventListener('message', replaceListener);
+      }
+      return;
+    }
+
+    if (data.message === 'gotLink') {
+      console.log('gotLink', data);
+      replace(data);
+      // attachClickListeners(findAdElements(AD_ANCHOR_CLASS_NAME));
+      win.removeEventListener('message', replaceListener);
+    }
+  }
+
+  /**
+   *
+   */
+  function replace(data) {
+    data.assets.forEach(asset => {
+      win.document.body.innerHTML = win.document.body.innerHTML.replace(
+        `${NATIVE_KEYS[asset.key]}:${data.adId}`,
+        asset.value
+      );
+    });
+  }
+
+  return {
+    scanForPlaceholders
+  };
+}

--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -3,6 +3,10 @@
  * values in native creative templates.
  */
 
+/*
+ * Native asset->key mapping from Prebid.js/src/constants.json
+ * https://github.com/prebid/Prebid.js/blob/8635c91942de9df4ec236672c39b19448545a812/src/constants.json#L67
+ */
 const NATIVE_KEYS = {
   title: 'hb_native_title',
   body: 'hb_native_body',

--- a/src/nativeTrackerManager.js
+++ b/src/nativeTrackerManager.js
@@ -13,7 +13,7 @@ export function newNativeTrackerManager(win) {
     let adElements = win.document.getElementsByClassName(className);
     return adElements || [];
   }
-  
+
   function readAdIdFromElement(adElements) {
     let adId = (adElements.length > 0) &&
       adElements[0].attributes &&
@@ -21,7 +21,7 @@ export function newNativeTrackerManager(win) {
       adElements[0].attributes[AD_DATA_ADID_ATTRIBUTE].value;
     return adId || '';
   }
-  
+
   function readAdIdFromEvent(event) {
     let adId =
       event &&
@@ -29,35 +29,35 @@ export function newNativeTrackerManager(win) {
       event.target.attributes &&
       event.target.attributes[AD_DATA_ADID_ATTRIBUTE] &&
       event.target.attributes[AD_DATA_ADID_ATTRIBUTE].value;
-  
+
     return adId || '';
   }
-  
+
   function loadClickTrackers(event) {
     let adId = readAdIdFromEvent(event);
     fireTracker(adId, 'click');
   }
-  
+
   function loadImpTrackers(adElements) {
     let adId = readAdIdFromElement(adElements);
     fireTracker(adId, 'impression');
   }
-  
+
   function fireTracker(adId, action) {
     if (adId === '') {
       console.warn('Prebid tracking event was missing \'adId\'.  Was adId macro set in the HTML attribute ' + AD_DATA_ADID_ATTRIBUTE + 'on the ad\'s anchor element');
     } else {
       let message = { message: 'Prebid Native', adId: adId };
-  
+
       // fires click trackers when called via link
       if (action === 'click') {
         message.action = 'click';
       }
-  
+
       win.parent.postMessage(JSON.stringify(message), publisherDomain);
     }
   }
-  
+
   // START OF MAIN CODE
   let startTrackers = function (tagData) {
     let parsedUrl = parseUrl(tagData && tagData.pubUrl);
@@ -67,7 +67,7 @@ export function newNativeTrackerManager(win) {
     for (let i = 0; i < adElements.length; i++) {
       adElements[i].addEventListener('click', loadClickTrackers, true);
     }
-  
+
     // fires native impressions on creative load
     if (adElements.length > 0) {
       loadImpTrackers(adElements);

--- a/src/nativeTrackers.js
+++ b/src/nativeTrackers.js
@@ -1,10 +1,6 @@
-import { newNativeAssetManager } from './nativeAssetManager';
 import { newNativeTrackerManager } from './nativeTrackerManager';
 
 window.pbNativeTag = (window.pbNativeTag || {});
-
 const nativeTrackerManager = newNativeTrackerManager(window);
-window.pbNativeTag.startTrackers = nativeTrackerManager.startTrackers;
 
-const nativeAssetManager = newNativeAssetManager(window);
-window.pbNativeTag.loadAssets = nativeAssetManager.scanForPlaceholders;
+window.pbNativeTag.startTrackers = nativeTrackerManager.startTrackers;

--- a/src/nativeTrackers.js
+++ b/src/nativeTrackers.js
@@ -1,6 +1,10 @@
+import { newNativeAssetManager } from './nativeAssetManager';
 import { newNativeTrackerManager } from './nativeTrackerManager';
 
 window.pbNativeTag = (window.pbNativeTag || {});
-const nativeTrackerManager = newNativeTrackerManager(window);
 
+const nativeTrackerManager = newNativeTrackerManager(window);
 window.pbNativeTag.startTrackers = nativeTrackerManager.startTrackers;
+
+const nativeAssetManager = newNativeAssetManager(window);
+window.pbNativeTag.loadAssets = nativeAssetManager.scanForPlaceholders;

--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -1,0 +1,83 @@
+import { expect } from 'chai';
+import { merge } from 'lodash';
+import { newNativeAssetManager } from 'src/nativeAssetManager';
+import { mocks } from 'test/helpers/mocks';
+
+const AD_ID = 'abc123';
+
+const mockDocument = {
+  getWindowObject: function() {
+    return {
+      addEventListener: sinon.spy(),
+      removeEventListener: sinon.spy(),
+      parent: { postMessage: sinon.spy() },
+    };
+  }
+};
+
+// creates mock postmessage response from prebid's native.js:getAssetMessage
+function createResponder(assets) {
+  return function(type, listener) {
+    if (type !== 'message') { return; }
+
+    const data = { message: 'assetResponse', adId: AD_ID, assets };
+    listener({ data: JSON.stringify(data) });
+  };
+}
+
+describe('nativeTrackerManager', () => {
+  let win;
+
+  beforeEach(() => {
+    win = merge(mocks.createFakeWindow(), mockDocument.getWindowObject());
+  });
+
+  it('replaces native placeholders with their asset values', () => {
+    win.document.body.innerHTML = `
+      <h1>hb_native_title</h1>
+      <p>hb_native_body:${AD_ID}</p>
+      <a href="hb_native_linkurl:${AD_ID}">Click Here</a>
+    `;
+    win.addEventListener = createResponder([
+      { key: 'body', value: 'new value' },
+      { key: 'clickUrl', value: 'http://www.example.com' },
+    ]);
+
+    const nativeAssetManager = newNativeAssetManager(win);
+    nativeAssetManager.loadAssets(AD_ID);
+
+    expect(win.document.body.innerHTML).to.include('<p>new value</p>');
+    expect(win.document.body.innerHTML).to.include(`
+      <a href="http://www.example.com">Click Here</a>
+    `);
+    // title was not a requested asset so this should stay as is
+    expect(win.document.body.innerHTML).to.include('<h1>hb_native_title</h1>');
+  });
+
+  it('attaches and removes message listeners', () => {
+    win.document.body.innerHTML = `<h1>hb_native_title:${AD_ID}</h1>`;
+    win.addEventListener = createResponder();
+
+    const nativeAssetManager = newNativeAssetManager(win);
+    nativeAssetManager.loadAssets(AD_ID);
+
+    expect(win.parent.postMessage.callCount).to.equal(1);
+    expect(win.removeEventListener.callCount).to.equal(1);
+  });
+
+  it('does not replace anything if no placeholders found', () => {
+    const html = `
+      <h1>Native Ad</h1>
+      <p>Cool Description</p>
+      <a href="http://www.example.com">Click</a>
+    `;
+
+    win.document.body.innerHTML = html;
+    win.addEventListener = createResponder();
+
+    const nativeAssetManager = newNativeAssetManager(win);
+    nativeAssetManager.loadAssets(AD_ID);
+
+    expect(win.document.body.innerHTML).to.equal(html);
+  });
+});


### PR DESCRIPTION
Adds new functionality called in `window.pbNativeTag.startTrackers()` to scan for and replace any placeholder values sent with via the new config option in https://github.com/prebid/Prebid.js/pull/3573