### PR TITLE
Add ssl support back to gulp webserver

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,8 @@ gulp.task('connect', () => {
       livereload: true,
       port,
       directoryListing: true,
-      open: true
+      open: true,
+      https: argv.https
     }));
 });
 


### PR DESCRIPTION
When we switched from gulp connect to gulp-webserver, we forgot to add ssl flag.