### PR TITLE
Buyer user ids script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,9 +23,9 @@ const dateString = 'Updated : ' + (new Date()).toISOString().substring(0, 10);
 const banner = '/* <%= creative.name %> v<%= creative.version %>\n' + dateString + ' */\n';
 const port = 9990;
 
-gulp.task('serve', ['clean', 'test', 'build-dev', 'build-native-dev', 'build-cookie-sync', 'connect', 'watch']);
+gulp.task('serve', ['clean', 'test', 'build-dev', 'build-native-dev', 'build-cookie-sync', 'build-uid-dev', 'connect', 'watch']);
 
-gulp.task('build', ['build-prod', 'build-cookie-sync', 'build-native']);
+gulp.task('build', ['build-prod', 'build-cookie-sync', 'build-native', 'build-uid']);
 
 gulp.task('clean', () => {
   return gulp.src(['dist/', 'build/'], {
@@ -72,6 +72,28 @@ gulp.task('build-native', () => {
   cloned.output.filename = 'native-trk.js';
 
   return gulp.src(['src/nativeTrackers.js'])
+    .pipe(webpackStream(cloned))
+    .pipe(uglify())
+    .pipe(header('/* v<%= creative.version %>\n' + dateString + ' */\n', { creative: creative }))
+    .pipe(gulp.dest('dist'));
+});
+
+gulp.task('build-uid-dev', () => {
+  var cloned = _.cloneDeep(webpackConfig);
+  delete cloned.devtool;
+  cloned.output.filename = 'uid.js';
+  
+  return gulp.src(['src/ssp-userids/uid.js'])
+    .pipe(webpackStream(cloned))
+    .pipe(gulp.dest('build'));
+});
+
+gulp.task('build-uid', () => {
+  var cloned = _.cloneDeep(webpackConfig);
+  delete cloned.devtool;
+  cloned.output.filename = 'uid.js';
+  
+  return gulp.src(['src/ssp-userids/uid.js'])
     .pipe(webpackStream(cloned))
     .pipe(uglify())
     .pipe(header('/* v<%= creative.version %>\n' + dateString + ' */\n', { creative: creative }))

--- a/src/ssp-userids/commons.js
+++ b/src/ssp-userids/commons.js
@@ -1,0 +1,98 @@
+/**
+ * Store data in local storage
+ * @param {string} key 
+ * @param {string} value 
+ */
+
+export function setDataInLocalStorage(key, value) {
+  if (hasLocalStorage()) {
+    window.localStorage.setItem(key, value);
+  }
+}
+
+/**
+ * Get data from local storage
+ * @param {string} key 
+ */
+export function getDataFromLocalStorage(key) {
+  if (hasLocalStorage()) {
+    return window.localStorage.getItem(key);
+  }
+}
+
+/**
+ * Check local storage is supported or not
+ */
+export function hasLocalStorage() {
+  try {
+    return !!window.localStorage;
+  } catch (e) {
+    console.log('Local storage api disabled');
+  }
+}
+
+export function timestamp() {
+  return new Date().getTime();
+}
+
+export function ajax(url, callback, data, options = {}) {
+  try {
+    let timeout = 3000;
+    let x;
+    let method = options.method || (data ? 'POST' : 'GET');
+
+    let callbacks = typeof callback === 'object' ? callback : {
+      success: function() {
+        console.log('xhr success');
+      },
+      error: function(e) {
+        console.log('xhr error', null, e);
+      }
+    };
+
+    if (typeof callback === 'function') {
+      callbacks.success = callback;
+    }
+
+    x = new window.XMLHttpRequest();
+    x.onreadystatechange = function () {
+      if (x.readyState === 4) {
+        let status = x.status;
+        if ((status >= 200 && status < 300) || status === 304) {
+          callbacks.success(x.responseText, x);
+        } else {
+          callbacks.error(x.statusText, x);
+        }
+      }
+    };
+    x.ontimeout = function () {
+      console.log('xhr timeout after ', x.timeout, 'ms');
+    };
+
+    if (method === 'GET' && data) {
+      let urlInfo = parseURL(url, options);
+      Object.assign(urlInfo.search, data);
+      url = formatURL(urlInfo);
+    }
+
+    x.open(method, url);
+    // IE needs timoeut to be set after open - see #1410
+    x.timeout = timeout;
+
+    if (options.withCredentials) {
+      x.withCredentials = true;
+    }
+    if (options.preflight) {
+      x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+    }
+    x.setRequestHeader('Content-Type', options.contentType || 'text/plain');
+
+    if (method === 'POST' && data) {
+      x.send(data);
+    } else {
+      x.send();
+    }
+  } catch (error) {
+    console.log('xhr construction', error);
+  }
+}

--- a/src/ssp-userids/uid.js
+++ b/src/ssp-userids/uid.js
@@ -22,7 +22,7 @@ const REFRESH_IN_DAYS = 14;
  */
 export function getBuyerUids(callback) {
   let uidData = commons.getDataFromLocalStorage(STORAGE_KEY);
-  if (hasValidData(uidData)) {
+  if (hasInvalidData(uidData)) {
     loadData(callback);
   } else {
     try {
@@ -54,7 +54,7 @@ export function loadData(callback) {
   }
 
   let uidData = commons.getDataFromLocalStorage(STORAGE_KEY);
-  if (hasValidData(uidData)) {
+  if (hasInvalidData(uidData)) {
     commons.ajax(ENDPOINT, saveData, null, {
       withCredentials: true
     });
@@ -66,8 +66,8 @@ export function loadData(callback) {
  * @param {Object} uidData 
  * @returns {boolean}
  */
-function hasValidData(uidData) {
-  return !uidData || commons.timestamp() < uidData.lastUpdated + REFRESH_IN_DAYS * 24 * 60 * 60 * 1000
+function hasInvalidData(uidData) {
+  return !uidData || commons.timestamp() > uidData.lastUpdated + REFRESH_IN_DAYS * 24 * 60 * 60 * 1000
 }
 
 function noop() {}

--- a/src/ssp-userids/uid.js
+++ b/src/ssp-userids/uid.js
@@ -1,0 +1,74 @@
+/**
+ * This script returns the ssp buyer user id's. 
+ * Usage: 
+ * Load the script on the page from jsDelivr <TODO update url here>
+ * window.pbs.getBuyerUids(function(error, uids) {
+ *    // use uids here
+ * })
+ */
+
+import * as commons from './commons';
+
+window.pbs = (window.pbs || {})
+window.pbs.getBuyerUids = getBuyerUids;
+
+const ENDPOINT = 'https://prebid.adnxs.com/pbs/v1/getuids';
+const STORAGE_KEY = 'ssp-buyeruids';
+const REFRESH_IN_DAYS = 14;
+
+/**
+ * This functions calls the callback when buyer userid's is ready
+ * @param {function} callback 
+ */
+export function getBuyerUids(callback) {
+  let uidData = commons.getDataFromLocalStorage(STORAGE_KEY);
+  if (hasValidData(uidData)) {
+    loadData(callback);
+  } else {
+    try {
+      uidData = JSON.parse(uidData);
+    } catch (e) {
+      callback(e, null);
+      return;
+    }
+    delete uidData.lastUpdated;
+    callback(null, uidData);
+  }
+}
+
+/**
+ * Gets the data from prebid server getuid endpoint and store it in local storage
+ * @param {function} callback 
+ */
+export function loadData(callback) {
+  function saveData(response) {
+    try {
+      response = JSON.parse(response);
+      response['lastUpdated'] = commons.timestamp();
+      commons.setDataInLocalStorage(STORAGE_KEY, JSON.stringify(response));
+      delete response.lastUpdated;
+      callback(null, response);
+    } catch (e) {
+      callback(e, null);
+    }
+  }
+
+  let uidData = commons.getDataFromLocalStorage(STORAGE_KEY);
+  if (hasValidData(uidData)) {
+    commons.ajax(ENDPOINT, saveData, null, {
+      withCredentials: true
+    });
+  }
+}
+
+/**
+ * Check whether buyer id data is not null and is not expired
+ * @param {Object} uidData 
+ * @returns {boolean}
+ */
+function hasValidData(uidData) {
+  return !uidData || commons.timestamp() < uidData.lastUpdated + REFRESH_IN_DAYS * 24 * 60 * 60 * 1000
+}
+
+function noop() {}
+loadData(noop);

--- a/test/spec/uid_spec.js
+++ b/test/spec/uid_spec.js
@@ -1,0 +1,70 @@
+import { getBuyerUids, loadData } from 'src/ssp-userids/uid';
+import * as commons from 'src/ssp-userids/commons';
+import { expect } from 'chai';
+
+describe('uid module', function() {
+  let xhr;
+  let requests;
+  let saveStorageStub;
+  let getStorageStub;
+
+  before(function() {
+    xhr = sinon.useFakeXMLHttpRequest();
+    xhr.onCreate = function(xhr) {
+      requests.push(xhr);
+    }
+  });
+
+  after(function(){
+    xhr.restore();
+  });
+
+  beforeEach(function() {
+    requests = [];
+    saveStorageStub = sinon.stub(commons, 'setDataInLocalStorage');
+    getStorageStub = sinon.stub(commons, 'getDataFromLocalStorage');
+  });
+
+  afterEach(function() {
+    saveStorageStub.restore();
+    getStorageStub.restore();
+  });
+
+  it('should save data in local storage when script is loaded', function() {
+    getStorageStub.returns(null);
+    let response = '{"buyeruids": {"appnexus":"12345"}}';
+    loadData(sinon.spy());
+    requests[0].respond(
+      200, 
+      { "Content-Type": "text/plain" },
+      response
+    );
+    expect(JSON.parse(saveStorageStub.args[0][1])).to.have.all.keys(['buyeruids', 'lastUpdated'])
+    expect(saveStorageStub.callCount).to.equal(1);
+  });
+
+  it('should get buyer ids from local storage', function() {
+    let response = '{"buyeruids": {"appnexus":"12345"},"lastUpdated":"123456"}';
+    getStorageStub.returns(response);
+    let callbackSpy = sinon.spy();
+    getBuyerUids(callbackSpy);
+    let expectedResponse = {
+      "buyeruids": {"appnexus":"12345"}
+    }
+    expect(callbackSpy.calledWith(null, expectedResponse)).to.be.true;
+  });
+
+  it('should get buyer ids from endpoint when local storage not supported', function() {
+    let response = '{"buyeruids": {"appnexus":"12345"}}';
+    getStorageStub.returns(undefined);
+    let callbackSpy = sinon.spy();
+    getBuyerUids(callbackSpy);
+    requests[0].respond(
+      200, 
+      { "Content-Type": "text/plain" },
+      response
+    );
+    expect(callbackSpy.calledWith(null, JSON.parse(response))).to.be.true;
+    expect(saveStorageStub.callCount).to.equal(1);
+  });
+});

--- a/test/spec/uid_spec.js
+++ b/test/spec/uid_spec.js
@@ -52,6 +52,7 @@ describe('uid module', function() {
       "buyeruids": {"appnexus":"12345"}
     }
     expect(callbackSpy.calledWith(null, expectedResponse)).to.be.true;
+    expect(requests.length).to.equal(0);
   });
 
   it('should get buyer ids from endpoint when local storage not supported', function() {


### PR DESCRIPTION
This script gets the buyer user ids from prebid server getuids endpoint.
Use case for now: In Prebid server long form support, SSAI vendor needs to get buyer user id to send it in prebid server request payload. 

It will be available via jsDelivr. Path to be shared soon
Usage. 
```
<script type="text/javascript" src="<uid url>"></script>
<script type="text/javascript">
  window.pbs.getBuyerUids(function(err, uids) { 
    // Use uids here
  })
</script>
```