### PR TITLE
add support for alternative native asset substitution

### DIFF
--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -35,7 +35,7 @@ const NATIVE_CLASS_IDS = {
 export function newNativeAssetManager(win) {
   let callback;
   let errorCountEscapeHatch = 0;
-  let tokenType;
+  let tokenType = 'default';
 
   /*
    * Entry point to search for placeholderes and set up postmessage roundtrip
@@ -76,7 +76,9 @@ export function newNativeAssetManager(win) {
       tokensToCheck.forEach(function(token) {
         if (win.document.body.innerHTML.indexOf(token) !== -1) {
           placeholderIndex = win.document.body.innerHTML.indexOf(token);
-          tokenType = (token === sendIdPlaceholder) ? 'sendId' : 'hardKey';
+          if (tokenType === 'default') {
+            tokenType = (token === sendIdPlaceholder) ? 'sendId' : 'hardKey';
+          }
         }
       });
 

--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -25,14 +25,14 @@ function createResponder(assets) {
   };
 }
 
-describe('nativeTrackerManager', () => {
+describe('nativeAssetManager', () => {
   let win;
 
   beforeEach(() => {
     win = merge(mocks.createFakeWindow(), mockDocument.getWindowObject());
   });
 
-  it('replaces native placeholders with their asset values', () => {
+  it('replaces native placeholders with their asset values while using sendId notation', () => {
     win.document.body.innerHTML = `
       <h1>hb_native_title</h1>
       <p>hb_native_body:${AD_ID}</p>
@@ -50,6 +50,39 @@ describe('nativeTrackerManager', () => {
     expect(win.document.body.innerHTML).to.include(`
       <a href="http://www.example.com">Click Here</a>
     `);
+    // title was not a requested asset so this should stay as is
+    expect(win.document.body.innerHTML).to.include('<h1>hb_native_title</h1>');
+  });
+
+  it('replaces native placeholders with their asset values while using hardKey notation', () => {
+    win.document.body.innerHTML = `
+      <h1>hb_native_title</h1>
+      <p>%%hb_native_body%%</p>
+      <a href="%%hb_native_linkurl%%">Click Here</a>
+      <img class="pb-icon" height="10" width="10" />
+    `;
+    win.document.body.getElementsByClassName = sinon.stub().returns([{
+      setAttribute: function(property, val) {
+        let attribute = `class="pb-icon" ${property}="${val}"`
+        win.document.body.innerHTML = win.document.body.innerHTML.replace('class="pb-icon"', attribute);
+      }
+    }]);
+    win.addEventListener = createResponder([
+      { key: 'body', value: 'new value' },
+      { key: 'clickUrl', value: 'http://www.example.com' },
+      { key: 'icon', value: 'http://my.fake.images/somewhere/lost/1x1.gif' }
+    ]);
+
+    const nativeAssetManager = newNativeAssetManager(win);
+    nativeAssetManager.loadAssets(AD_ID);
+
+    expect(win.document.body.innerHTML).to.include('<p>new value</p>');
+    expect(win.document.body.innerHTML).to.include(`
+      <a href="http://www.example.com">Click Here</a>
+    `);
+    expect(win.document.body.innerHTML).to.include(`
+      <img class="pb-icon" src="http://my.fake.images/somewhere/lost/1x1.gif" height="10" width="10" />
+    `)
     // title was not a requested asset so this should stay as is
     expect(win.document.body.innerHTML).to.include('<h1>hb_native_title</h1>');
   });


### PR DESCRIPTION
I'm creating this PR to explain the changes and to get feedback on the implementation.

As per current discussions, we are **NOT** going to merge this PR into the master branch at this time; which is why this is only a draft PR.

## Summary of changes
As the title implies, this PR adds a different way to insert the native bid's assets into the native creative template.  The key difference with this approach is that it does not rely on the native targeting keys being passed into the adserver and having the adserver replace their macros in the creative code.

Instead this approach (mostly) uses hard-coded keys/placeholders in the native creative code to perform the substitution logic.  

Below is an example of the native creative code (at least the HTML part of it) using the updated placeholders that work with the new logic:
```
<div class="sponsored-post">
    <div class="thumbnail"></div>
    <div class="content">
        <h1>
        	<a href="%%CLICK_URL_UNESC%%%%hb_native_linkurl%%" target="_blank" class="pb-click" pbAdId="%%PATTERN:hb_adid%%">
  %%hb_native_title%%
</a>
        </h1>
        <p>%%hb_native_body%%</p>
        <div class="attribution">
			<img class="pb-icon" alt="icon" height="10" width="10">
			%%hb_native_brand%%
		</div>
    </div>
</div>

<script src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/native-trk.js"></script>
<script>
  	let pbNativeTagData = {};
  	pbNativeTagData.pubUrl = "%%PATTERN:url%%";
  	window.pbNativeTag.startTrackers(pbNativeTagData);
</script>
```

When the code in the `newNativeAssetManager` runs with the above template, it will:
- Detect which native assets are 'in-use' in the template by looking for the normal prebid native keys surrounded by double % characters (eg %%hb_native_brand%%).
- Once it identifies all the assets in play, it'll make a postMessage request to Prebid.js to lookup the bid's native data properties
- Once it receives the response, it'll go through the template code and replace the placeholders with the values from the bid - at which point the ad would be rendered properly.

In the case of the assets `hb_native_image` and/or `hb_native_icon`, small tweak to the above logic is done.  The code will instead:
- Look for html tags with the class value `pb-image` or `pb-icon`.  These class values would be set by the publisher to represent the `<img>` tag is where the corresponding image/icon file should go.
- If these classes were present, the code will add the `src` attribute to the corresponding `<img>` tag to render the image.  

If the image assets were to use the same substitution method used by the other assets, the browser would throw an error when it initially tries to render the `<img>` tag while it still had the placeholder value (since the native script runs after the HTML code has already been preloaded by the browser).  The creative would still render properly, but the error would still occur in the browser's console logs.  So this unique approach for handling the image related assets was implemented to avoid this unsightly error.

## Other notes
- Any native assets set in the CSS portion of the native creative template (eg `hb_native_image`) still require the old native key logic to perform its substitution.  The new code only has access to the HTML side of the creative template.
- This new logic is ideally meant to replace the previously designed `sendId` functionality.  However that logic was not removed from this code so as to avoid any breaking changes.  There is no need to mix the two together in a single creative template (we currently determine which to use based off the first token it finds in the template).
- The updated creative template still utilizes some of the base targeting keys (eg `hb_adid`).  These are needed to get some basic information of the winning bid into the creative template.