### PR TITLE
Safe frame issue fix

### DIFF
--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -66,10 +66,11 @@ export function newRenderingManager(win, environment) {
    * @param {string} pubUrl Url of publisher page
    */
   function renderCrossDomain(adId, pubAdServerDomain = '', pubUrl) {
+    let windowLocation = window.location;
     let parsedUrl = utils.parseUrl(pubUrl);
     let publisherDomain = parsedUrl.protocol + '://' + parsedUrl.host;
-    let adServerDomain = (pubAdServerDomain !== '') ? pubAdServerDomain : GOOGLE_IFRAME_HOSTNAME;
-    let fullAdServerDomain = parsedUrl.protocol + '://' + adServerDomain;
+    let adServerDomain = pubAdServerDomain || GOOGLE_IFRAME_HOSTNAME;
+    let fullAdServerDomain = windowLocation.protocol + '//' + adServerDomain;
 
     function renderAd(ev) {
       let key = ev.message ? 'message' : 'data';


### PR DESCRIPTION
Seems like recently GAM has started always returning Safe Frames as HTTPS.

So our code which assumes our current executing iframe had the same protocol as the publishers domain needs to be updated.

We will get the protocol from the `window.location` now.

Here are examples of this in different browsers when my test page is loaded via HTTP but the iframe delivered is in HTTPS:

CHROME:

Before:
![image](https://user-images.githubusercontent.com/13972794/60297805-e5ac9d00-98dd-11e9-8faf-d1823513cfc7.png)


After:
![image](https://user-images.githubusercontent.com/13972794/60297821-f0ffc880-98dd-11e9-94e9-ce7da786e04f.png)


Notice the `Mixed-Content` warning will happen now because prebid and bidders expected HTTP, so may have responded with HTTP content.


FireFox:

Before:
![image](https://user-images.githubusercontent.com/13972794/60297902-21476700-98de-11e9-9829-d8c234d10ed6.png)

Notice that Firefox actually logged the error that caused ads not to render in this scenario!

After:
![image](https://user-images.githubusercontent.com/13972794/60298065-7d11f000-98de-11e9-8cf8-5d60980731fc.png)


Safari:

Before:
![image](https://user-images.githubusercontent.com/13972794/60298110-95820a80-98de-11e9-9a41-e900725f2c18.png)


After:
![image](https://user-images.githubusercontent.com/13972794/60298129-9fa40900-98de-11e9-9b30-dd299f9e6b34.png)



IE 11

Before:
![image](https://user-images.githubusercontent.com/13972794/60298609-bb5bdf00-98df-11e9-8fd2-88599ec944f1.png)



After:

![image](https://user-images.githubusercontent.com/13972794/60298521-8f405e00-98df-11e9-915e-20fe6dab0098.png)
