### PR TITLE
Fix for so that the impressionTrackers and jsTrackers are called once per adElement

### DIFF
--- a/src/nativeTrackerManager.js
+++ b/src/nativeTrackerManager.js
@@ -23,6 +23,13 @@ export function newNativeTrackerManager(win) {
     return adId || '';
   }
 
+  function readAdIdFromSingleElement(adElement) {
+    let adId =  adElement.attributes &&
+      adElement.attributes[AD_DATA_ADID_ATTRIBUTE] &&
+      adElement.attributes[AD_DATA_ADID_ATTRIBUTE].value;
+    return adId || '';
+  }
+
   function readAdIdFromEvent(event) {
     let adId =
       event &&
@@ -40,8 +47,10 @@ export function newNativeTrackerManager(win) {
   }
 
   function loadImpTrackers(adElements) {
-    let adId = readAdIdFromElement(adElements);
-    fireTracker(adId, 'impression');
+      for(var i = 0; i < adElements.length; i++){
+          let adId = readAdIdFromSingleElement(adElements[i]);
+          fireTracker(adId, 'impression');
+      }
   }
 
   function attachClickListeners(adElements) {


### PR DESCRIPTION
This fix corrects an issue that occurs when multiple native placements use the `native-trk.js` script.

The previous code only grabbed the first adElement and executed the imp/js trackers for that ad.  This fix will detect all available elements and execute them appropriately.