### PR TITLE
Fix ci failing

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -1,9 +1,17 @@
 {
-  "bs_edge_15_windows_10": {
+  "bs_edge_16_windows_10": {
     "base": "BrowserStack",
     "os_version": "10",
     "browser": "edge",
-    "browser_version": "15.0",
+    "browser_version": "16.0",
+    "device": null,
+    "os": "Windows"
+  },
+  "bs_edge_17_windows_10": {
+    "base": "BrowserStack",
+    "os_version": "10",
+    "browser": "edge",
+    "browser_version": "17.0",
     "device": null,
     "os": "Windows"
   },
@@ -15,43 +23,43 @@
     "device": null,
     "os": "Windows"
   },
-  "bs_chrome_62_windows_10": {
+  "bs_chrome_72_windows_10": {
     "base": "BrowserStack",
     "os_version": "10",
     "browser": "chrome",
-    "browser_version": "62.0",
+    "browser_version": "72.0",
     "device": null,
     "os": "Windows"
   },
-  "bs_chrome_61_windows_10": {
+  "bs_chrome_71_windows_10": {
     "base": "BrowserStack",
     "os_version": "10",
     "browser": "chrome",
-    "browser_version": "61.0",
+    "browser_version": "71.0",
     "device": null,
     "os": "Windows"
   },
-  "bs_firefox_58_windows_10": {
+  "bs_firefox_65_windows_10": {
     "base": "BrowserStack",
     "os_version": "10",
     "browser": "firefox",
-    "browser_version": "58.0",
+    "browser_version": "65.0",
     "device": null,
     "os": "Windows"
   },
-  "bs_firefox_57_windows_10": {
+  "bs_firefox_64_windows_10": {
     "base": "BrowserStack",
     "os_version": "10",
     "browser": "firefox",
-    "browser_version": "57.0",
+    "browser_version": "64.0",
     "device": null,
     "os": "Windows"
   },
-  "bs_safari_9.1_mac_elcapitan": {
+  "bs_safari_12.1_mac_mojave": {
     "base": "BrowserStack",
-    "os_version": "El Capitan",
+    "os_version": "Mojave",
     "browser": "safari",
-    "browser_version": "9.1",
+    "browser_version": "12.1",
     "device": null,
     "os": "OS X"
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,18 +154,25 @@ gulp.task('test', ['serve-e2e'], (done) => {
     return execa(wdioCmd, wdioOpts, { stdio: 'inherit' });
   } else {
     let karmaConf = karmaConfMaker(false, argv.browserstack, argv.watch);
-    const server = new KarmaServer(karmaConf, function(exitCode) {
-      if (exitCode) {
-        done(new Error('Karma tests failed with exit code', exitCode));
-        process.exit(exitCode);
-      } else {
-        done();
-        process.exit(exitCode);
-      }
-    });
-    server.start();
+    new KarmaServer(karmaConf, newKarmaCallback(done)).start();
   }
 });
+
+function newKarmaCallback(done) {
+  return function(exitCode) {
+    if (exitCode) {
+      done(new Error('Karma tests failed with exit code' + exitCode));
+      if (argv.browserstack) {
+        process.exit(exitCode);
+      }
+    } else {
+      done();
+      if (argv.browserstack) {
+        process.exit(exitCode);
+      }
+    }
+  } 
+}
 
 gulp.task('serve-e2e', () => {
   if (argv.e2e) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,16 @@ gulp.task('test', ['serve-e2e'], (done) => {
     return execa(wdioCmd, wdioOpts, { stdio: 'inherit' });
   } else {
     let karmaConf = karmaConfMaker(false, argv.browserstack, argv.watch);
-    new KarmaServer(karmaConf, newKarmaCallback(done)).start();
+    const server = new KarmaServer(karmaConf, function(exitCode) {
+      if (exitCode) {
+        done(new Error('Karma tests failed with exit code', exitCode));
+        process.exit(exitCode);
+      } else {
+        done();
+        process.exit(exitCode);
+      }
+    });
+    server.start();
   }
 });
 
@@ -163,16 +172,6 @@ gulp.task('serve-e2e', () => {
     return gulp.start('serve');
   }
 });
-
-function newKarmaCallback(done) {
-  return function (exitCode) {
-    if (exitCode) {
-      done(new Error('Karma tests failed with exit code ' + exitCode));
-    } else {
-      done();
-    }
-  }
-}
 
 gulp.task('set-test-node-env', () => {
   return process.env.NODE_ENV = 'test';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid-universal-creative",
-  "version": "1.5.0-pre",
+  "version": "1.6.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4201,7 +4201,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4222,12 +4223,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4242,17 +4245,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4369,7 +4375,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4381,6 +4388,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4395,6 +4403,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4402,12 +4411,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4426,6 +4437,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4506,7 +4518,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4518,6 +4531,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4603,7 +4617,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4639,6 +4654,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4658,6 +4674,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4701,12 +4718,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/e2e/specs/hello_world_banner_non_sf.spec.js
+++ b/test/e2e/specs/hello_world_banner_non_sf.spec.js
@@ -9,6 +9,6 @@ describe('banner', function() {
     browser.waitForExist('iframe[id="google_ads_iframe_/19968336/puc_test_banner_nonsf_0"]');
     let creativeIframe = $('iframe[id="google_ads_iframe_/19968336/puc_test_banner_nonsf_0"]').value;
     browser.frame(creativeIframe);
-    assert.equal(browser.isVisible('body > a > img'), true);
+    assert.equal(browser.isVisible('body > div[class="GoogleActiveViewElement"] > a > img'), true);
   }, 2);
 })

--- a/testpages/hello_world_banner_non-sf.html
+++ b/testpages/hello_world_banner_non-sf.html
@@ -52,11 +52,6 @@
         });
       });
     }
-
-    // setTimeout(function () {
-    //   sendAdserverRequest();
-    // }, PREBID_TIMEOUT);
-
   </script>
 
   <script>

--- a/testpages/hello_world_banner_non-sf.html
+++ b/testpages/hello_world_banner_non-sf.html
@@ -53,9 +53,9 @@
       });
     }
 
-    setTimeout(function () {
-      sendAdserverRequest();
-    }, PREBID_TIMEOUT);
+    // setTimeout(function () {
+    //   sendAdserverRequest();
+    // }, PREBID_TIMEOUT);
 
   </script>
 

--- a/testpages/outstream_non-sf.html
+++ b/testpages/outstream_non-sf.html
@@ -54,9 +54,9 @@
       });
     }
 
-    setTimeout(function () {
-      initAdserver();
-    }, PREBID_TIMEOUT);
+    // setTimeout(function () {
+    //   initAdserver();
+    // }, PREBID_TIMEOUT);
 
     googletag.cmd.push(function () {
       var slot1 = googletag.defineSlot('/19968336/puc_test_outstream_nonsf', [1, 1], 'div-gpt-ad-1536590534855-0').addService(googletag.pubads());

--- a/testpages/outstream_non-sf.html
+++ b/testpages/outstream_non-sf.html
@@ -54,10 +54,6 @@
       });
     }
 
-    // setTimeout(function () {
-    //   initAdserver();
-    // }, PREBID_TIMEOUT);
-
     googletag.cmd.push(function () {
       var slot1 = googletag.defineSlot('/19968336/puc_test_outstream_nonsf', [1, 1], 'div-gpt-ad-1536590534855-0').addService(googletag.pubads());
       googletag.pubads().disableInitialLoad();

--- a/testpages/outstream_sf.html
+++ b/testpages/outstream_sf.html
@@ -54,10 +54,6 @@
       });
     }
 
-    // setTimeout(function () {
-    //   initAdserver();
-    // }, PREBID_TIMEOUT);
-
     googletag.cmd.push(function () {
       var slot1 = googletag.defineSlot('/19968336/puc_test_outstream_sf', [[300, 250]], 'div-gpt-ad-1536590946408-0').addService(googletag.pubads());
       googletag.pubads().disableInitialLoad();

--- a/testpages/outstream_sf.html
+++ b/testpages/outstream_sf.html
@@ -54,9 +54,9 @@
       });
     }
 
-    setTimeout(function () {
-      initAdserver();
-    }, PREBID_TIMEOUT);
+    // setTimeout(function () {
+    //   initAdserver();
+    // }, PREBID_TIMEOUT);
 
     googletag.cmd.push(function () {
       var slot1 = googletag.defineSlot('/19968336/puc_test_outstream_sf', [[300, 250]], 'div-gpt-ad-1536590946408-0').addService(googletag.pubads());


### PR DESCRIPTION
## Type of change

- [x] Build Related

## Description of change

Earlier, Circle CI used to fail because the command `gulp test --browserstack` didn't used to exit even after a successful run. This PR aims to fix that.