### PR TITLE
decoding winurl

### DIFF
--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -42,6 +42,8 @@ export function newRenderingManager(win, environment) {
     
     // check for winurl and replace BIDID token with value if it exists
     if (targetingData.winurl && targetingData.winbidid) {
+        // one level of decoding
+        targetingData.winurl=decodeURIComponent(targetingData.winurl);
         // test if BIDID exists in winurl, if BIDID doesn't exist log console warning
         if (targetingData.winurl.match(/=BIDID\b/)) {
           const replacedUrl = targetingData.winurl.replace(/=BIDID\b/, `=${targetingData.winbidid}`);


### PR DESCRIPTION
Did some testing on https://github.com/prebid/prebid-universal-creative/pull/75 and found that we're going to need to encode the hb_winurl or GAM won't pass it through. So adding a level of unencoding.