### PR TITLE
Safeframe fix

### DIFF
--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -118,11 +118,13 @@ export function newRenderingManager(win, environment) {
         if (adObject.mediaType === 'video') {
           console.log('Error trying to write ad.');
         } else if (ad) {
-          const iframe =  domHelper.getEmptyIframe(adObject.height, adObject.width);
+          const iframe =  domHelper.getEmptyIframe(height, width);
           body.appendChild(iframe);
           iframe.contentDocument.open();
           iframe.contentDocument.write(ad);
           iframe.contentDocument.close();
+          
+          resizeIframe(width, height);
         } else if (url) {
           const iframe = domHelper.getEmptyIframe(height, width);
           iframe.style.display = 'inline';
@@ -130,6 +132,8 @@ export function newRenderingManager(win, environment) {
           iframe.src = url;
 
           domHelper.insertElement(iframe, doc, 'body');
+
+          resizeIframe(width, height);
         } else {
           console.log(`Error trying to write ad. No ad for bid response id: ${id}`);
         }
@@ -301,6 +305,8 @@ export function newRenderingManager(win, environment) {
           width: width,
           height: height
         }, '*');
+        
+        resize();
       }
     }
   }


### PR DESCRIPTION
In some cases I see SafeFrames not being resized properly by GAM. The container DIV is the right size, the Prebid frame is the right size but the SafeFrame in between stays stuck at 1x1. Digging a bit into the code I saw that the cross-domain case doesn't call the `resizeIframe()` method -- maybe because GAM seems to have its own size detection feature... that doesn't always work. So why not use the SafeFrame API and fix that?
Also, calling the `resize()` method right after registering it seems to fix another bug(?) where only registering doesn't always trigger a resize.

The Prebid documentation should also indicate that `allowPushExpansion` has to be `true` for `googletag.SafeFrameConfig` (at least in GAM).