### PR TITLE
Use a global regex replace instead of string replace on native placeholders

### DIFF
--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -245,7 +245,7 @@ export function newNativeAssetManager(win) {
 
     (assets || []).forEach(asset => {
       const searchString = (adId) ? `${NATIVE_KEYS[asset.key]}:${adId}` : `${NATIVE_KEYS[asset.key]}`;
-      const searchStringRegex = new RegExp(searchString, "g");
+      const searchStringRegex = new RegExp(searchString, 'g');
       html = html.replace(searchStringRegex, asset.value);
     });
 

--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -244,8 +244,9 @@ export function newNativeAssetManager(win) {
     let html = document;
 
     (assets || []).forEach(asset => {
-      const searchString = (adId) ? `${NATIVE_KEYS[asset.key]}:${adId}` : `${NATIVE_KEYS[asset.key]}`
-      html = html.replace(searchString, asset.value);
+      const searchString = (adId) ? `${NATIVE_KEYS[asset.key]}:${adId}` : `${NATIVE_KEYS[asset.key]}`;
+      const searchStringRegex = new RegExp(searchString, "g");
+      html = html.replace(searchStringRegex, asset.value);
     });
 
     return html;

--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -55,6 +55,24 @@ describe('nativeTrackerManager', () => {
     expect(win.document.body.innerHTML).to.include('<h1>hb_native_title</h1>');
   });
 
+  it('replaces all occurrences of the placeholder if it appears more than once', () => {
+    win.document.body.innerHTML = `
+      <a href="hb_native_linkurl:${AD_ID}">Click Here</a>
+      <a href="hb_native_linkurl:${AD_ID}">Or Here</a>
+    `;
+    win.addEventListener = createResponder([{ key: 'clickUrl', value: 'http://www.example.com' }]);
+
+    const nativeAssetManager = newNativeAssetManager(win);
+    nativeAssetManager.loadAssets(AD_ID);
+
+    expect(win.document.body.innerHTML).to.include(`
+      <a href="http://www.example.com">Click Here</a>
+    `);
+    expect(win.document.body.innerHTML).to.include(`
+      <a href="http://www.example.com">Or Here</a>
+    `);
+  });
+
   it('attaches and removes message listeners', () => {
     win.document.body.innerHTML = `<h1>hb_native_title:${AD_ID}</h1>`;
     win.addEventListener = createResponder();


### PR DESCRIPTION
Native asset placeholders are currently replaced using a simple string replace. This replaces the first occurrence of the native asset placeholder in the native template HTML, but does not cover the case where the template contains multiple usages of the placeholder. This can occur because a native template may contain multiple clickable elements. For example, the native image and also the call to action may _both_ link to the click-through URL. 
Currently, the result of running the native tracker script is that the first clickable element will correctly resolve to a valid click-through URL, while any additional links still contain the placeholder `hb_native_linkurl:<ad_id>` and clicking the element results in a blank page / 400 response.
Testing this change locally, I am able to get all clickable elements to direct to a valid URL with no adverse effects, as far as I can tell.