### PR TITLE
add logic to detect prebid.js global

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -34,31 +34,48 @@ export function newEnvironment(win) {
     * @returns true if the environment is a Cross Domain
     */
   function isCrossDomain() {
-		return win.top !== win && !canInspectWindow(win);
-	}
-		
-	/**
-	 * Returns true if win's properties can be accessed and win is defined.
-	 * This functioned is used to determine if a window is cross-domained
-	 * from the perspective of the current window.
-	 * @param {!Window} win
-	 * @return {boolean}
-	 */
-	function canInspectWindow(win) {
-		try {
-			// force an exception in x-domain environments. #1509
-			win.top.location.toString();
-			let currentWindow;
-			do {
-				currentWindow = currentWindow ? currentWindow.parent : win;
-			}
-			while (currentWindow !== win.top);
-			return true;
-		} catch (e) {
-			return false;
-		}
-	}
-		
+    return win.top !== win && !canInspectWindow(win);
+  }
+
+  /**
+   * Returns true if win's properties can be accessed and win is defined.
+   * This functioned is used to determine if a window is cross-domained
+   * from the perspective of the current window.
+   * @param {!Window} win
+   * @return {boolean}
+   */
+  function canInspectWindow(win) {
+    try {
+      // force an exception in x-domain environments. #1509
+      win.top.location.toString();
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns true if we can find the prebid global object (eg pbjs) as we
+   * climb the accessible windows.  Return false if it's not found.
+   * @returns {boolean}
+   */
+  function canLocatePrebid() {
+    let result = false;
+    let currentWindow = win;
+    
+    while (!result) {
+      try {
+        if (currentWindow.$$PREBID_GLOBAL$$) {
+          result = true;
+          break;
+        }
+      } catch (e) { }
+      if (currentWindow === window.top) break;
+      
+      currentWindow = currentWindow.parent;
+    }
+    return result;
+  }
 
   /**
    * @param {String} env key value from auction, indicates the environment where tag is served
@@ -72,7 +89,8 @@ export function newEnvironment(win) {
     isMobileApp,
     isCrossDomain,
     isSafeFrame,
-    isAmp
+    isAmp,
+    canLocatePrebid
   }
 }
 

--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -34,7 +34,7 @@ export function newRenderingManager(win, environment) {
       renderAmpOrMobileAd(targetingData.cacheHost, targetingData.cachePath, targetingData.uuid, targetingData.size, targetingData.hbPb, true);
     } else if (environment.isAmp(targetingData.uuid)) {
       renderAmpOrMobileAd(targetingData.cacheHost, targetingData.cachePath, targetingData.uuid, targetingData.size, targetingData.hbPb);
-    } else if (environment.isCrossDomain()) {
+    } else if (!environment.canLocatePrebid()) {
       renderCrossDomain(targetingData.adId, targetingData.adServerDomain, targetingData.pubUrl);
     } else {
       renderLegacy(doc, targetingData.adId);

--- a/test/spec/environment_spec.js
+++ b/test/spec/environment_spec.js
@@ -43,17 +43,19 @@ describe('environment module', function() {
     expect(env.isAmp('some-uuid')).to.equal(true);
 	});
 	
-	it('should detect crossDomain', function() {
-		let localWindow = {
-			top: {
-				location: {
-					toString: () => { throw new Error('error')}
-				}
-			}
-		}
+	it('should detect Prebid in higher window', function() {
+    let localWindow = {
+      parent: {
+        parent: {
+          pbjs: {
+            fakeFn: () => {}
+          }
+        }
+      }
+    };
     const mockWin = merge(mocks.createFakeWindow('http://appnexus.com'), envMocks.getWindowObject(), localWindow);
     const env = newEnvironment(mockWin);
-    expect(env.isCrossDomain()).to.equal(true);
+    expect(env.canLocatePrebid()).to.equal(true);
 	});
   
   it('should detect mobile app', function() {

--- a/test/spec/renderingManager_spec.js
+++ b/test/spec/renderingManager_spec.js
@@ -230,7 +230,7 @@ describe('renderingManager', function() {
       const env = {
         isMobileApp: () => false,
         isAmp: () => false,
-        isCrossDomain: () => true
+        canLocatePrebid: () => false
       };
       const renderObject = newRenderingManager(mockWin, env);
       let ucTagData = {
@@ -268,7 +268,7 @@ describe('renderingManager', function() {
       const env = {
         isMobileApp: () => false,
         isAmp: () => false,
-        isCrossDomain: () => false
+        canLocatePrebid: () => true
       };
       const renderObject = newRenderingManager(mockWin, env);
 


### PR DESCRIPTION
This is a change to fix an issue reported in Prebid.js (https://github.com/prebid/Prebid.js/issues/4682).

This new logic tries to find the prebid.js global object by climbing the available windows.  If the prebid object isn't found - we're assuming it's blocked by a cross domain iframe.  This will help in situations where prebid.js is hosted inside a cross-domain iframe and the creative.js file can normally directly access prebid.js to render the bid.

We're preserving the old `isCrossDomain` logic for the amp use-case, to avoid the scope of impact.

Also cleaned up some of the formatting.