### PR TITLE
IE11 render blank in CrossDomain frame

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -221,7 +221,7 @@ export function parseUrl(url) {
     port: +parsed.port,
     pathname: parsed.pathname.replace(/^(?!\/)/, '/'),
     hash: (parsed.hash || '').replace(/^#/, ''),
-    host: parsed.host || window.location.host
+    host: (parsed.host || window.location.host).replace(/:(443|80)$/, '')
   };
 }
 


### PR DESCRIPTION
The combination IE11 in crossdomain frame cause `renderAd` to silent fail. 
I have pinpoint it to `parsedUrl.host` from the `utils.parseUrl(pubUrl)` function in utils is always returning the hostname + port. Even if its a default port. i.e :80 :443 

https://github.com/prebid/prebid-universal-creative/blob/6d435979bacd27a18b71c8c57ce13691611ad714/src/renderingManager.js#L91-L96

So `paseUrl('https://example.com')` is returning `host: example.com:443` which it [should not do for default ports](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/host)

<img src="https://user-images.githubusercontent.com/1073964/74341545-34913f00-4da8-11ea-9a4e-0061dc74aa8d.png" width="200" />

> The HTMLHyperlinkElementUtils.host property is a USVString containing the host, that is the hostname, and then, **if the port of the URL is nonempty**, a ':', and the port of the URL.

This cause `publisherDomain === origin` to not be equal. Resulting in a blank ad.
https://github.com/prebid/prebid-universal-creative/blob/6d435979bacd27a18b71c8c57ce13691611ad714/src/renderingManager.js#L108-L111
 
The only solution I came up with is to simply replace known ports from the `host` 
```js
    host: (parsed.host || window.location.host).replace(/:(443|80)$/, '')
```
 
Remember, this behaviour is in IE11 only (not testet earlier versions ) 

