### PR TITLE
native tracker manager click tracker not firing

### DIFF
--- a/src/nativeTrackerManager.js
+++ b/src/nativeTrackerManager.js
@@ -30,19 +30,7 @@ export function newNativeTrackerManager(win) {
     return adId || '';
   }
 
-  function readAdIdFromEvent(event) {
-    let adId =
-      event &&
-      event.target &&
-      event.target.attributes &&
-      event.target.attributes[AD_DATA_ADID_ATTRIBUTE] &&
-      event.target.attributes[AD_DATA_ADID_ATTRIBUTE].value;
-
-    return adId || '';
-  }
-
-  function loadClickTrackers(event) {
-    let adId = readAdIdFromEvent(event);
+  function loadClickTrackers(event, adId) {
     fireTracker(adId, 'click');
   }
 
@@ -57,7 +45,10 @@ export function newNativeTrackerManager(win) {
     adElements = adElements || findAdElements(AD_ANCHOR_CLASS_NAME);
 
     for (let i = 0; i < adElements.length; i++) {
-      adElements[i].addEventListener('click', listener, true);
+      let adId = readAdIdFromSingleElement(adElements[i]);
+      adElements[i].addEventListener('click', function(event) {
+        listener(event, adId);
+      }, true);
     }
   }
 
@@ -88,16 +79,16 @@ export function newNativeTrackerManager(win) {
         }
         const boundedLoadMobileClickTrackers = loadMobileClickTrackers.bind(null, clickTrackers);
         attachClickListeners(false, boundedLoadMobileClickTrackers);
-        
+
         (impTrackers || []).forEach(triggerPixel);
       }
       nativeAssetManager.loadMobileAssets(targetingData, cb);
     } else {
       let parsedUrl = parseUrl(targetingData && targetingData.pubUrl);
       publisherDomain = parsedUrl.protocol + '://' + parsedUrl.host;
-  
+
       let adElements = findAdElements(AD_ANCHOR_CLASS_NAME);
-      
+
       nativeAssetManager.loadAssets(
         readAdIdFromElement(adElements),
         attachClickListeners

--- a/test/spec/nativeTrackerManager_spec.js
+++ b/test/spec/nativeTrackerManager_spec.js
@@ -22,7 +22,7 @@ describe('nativeTrackerManager', function () {
   describe('load startTrackers', function () {
     let mockWin;
     let consoleWarn;
-    
+
     let tagData = {
       pubUrl: 'http://example.com'
     };
@@ -70,13 +70,6 @@ describe('nativeTrackerManager', function () {
         },
         addEventListener: ((type, listener, capture) => {
           listener({
-            target: {
-              attributes: {
-                pbAdId: {
-                  value: 'ad123'
-                }
-              }
-            }
           })
         })
       }];
@@ -96,16 +89,18 @@ describe('nativeTrackerManager', function () {
       expect(trimPort(postMessageTargetDomain)).to.equal(tagData.pubUrl);
     });
 
-    it('should verify the warning message was executed', function() { 
+    it('should verify 2 warning messages (one for impression, one for click) was executed', function() {
       mockWin.document.getElementsByClassName = () => [{
         addEventListener: ((type, listener, capture) => {
+          listener({
+          })
         })
       }];
 
       let nativeTracker = new newNativeTrackerManager(mockWin);
       nativeTracker.startTrackers(tagData);
 
-      expect(consoleWarn.callCount).to.equal(1);
+      expect(consoleWarn.callCount).to.equal(2);
     });
   });
 });


### PR DESCRIPTION
Refactor code inside `attachClickListeners`, so that it read adId from the `<a>` tag element instead of read it from `event.target`.
Code read from `event.target` has trouble when there is inner tag inside `<a>` tag, for example:
```<a href="%%CLICK_URL_UNESC%%%%PATTERN:hb_native_linkurl%%" target="_blank" class="pb-click" pbAdId="%%PATTERN:hb_adid%%"><p>%%PATTERN:hb_native_title%%<p></a>```
when click event fires, the `<p>` tag is the event.target, not `<a>` tag, in that case, original code inside function readAdIdFromEvent won't work.

Adjusted test case for it as well.