### PR TITLE
Adding back burl support

### DIFF
--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -227,7 +227,7 @@ export function newRenderingManager(win, environment) {
         }
       }
       if (bidObject.burl) {
-        utils.triggerBurl(bidObject.burl);
+        utils.triggerPixel(bidObject.burl);
       }
     }
   };


### PR DESCRIPTION
Burl support was removed in this [PR](https://github.com/prebid/prebid-universal-creative/commit/c4c0b4bcbdf767258bd76a9d3629c57cd58a0a61?branch=c4c0b4bcbdf767258bd76a9d3629c57cd58a0a61&diff=unified#diff-3274f1a37032fb0ae4e2823def0007c634e869ae0dfc304ff6a12c36513c3a52L134).

This change adds it back, but uses the existing triggerPixel function to accomplish it.