### PR TITLE
CookieSync: updates to include filterSettings for AMP

### DIFF
--- a/src/cookieSync.js
+++ b/src/cookieSync.js
@@ -17,6 +17,7 @@ const VALID_ENDPOINTS = {
 const ENDPOINT = sanitizeEndpoint(parseQueryParam('endpoint', window.location.search));
 const ENDPOINT_ARGS = sanitizeEndpointArgs(parseQueryParam('args', window.location.search));
 const BIDDER_ARGS = sanitizeBidders(parseQueryParam('bidders', window.location.search));
+const IS_AMP = sanitizeSource(parseQueryParam('source', window.location.search));
 const maxSyncCountParam = parseQueryParam('max_sync_count', window.location.search);
 const MAX_SYNC_COUNT = sanitizeSyncCount(parseInt((maxSyncCountParam) ? maxSyncCountParam : 10, 10));
 const GDPR = sanitizeGdpr(parseInt(parseQueryParam('gdpr', window.location.search), 10));
@@ -182,6 +183,15 @@ function sanitizeEndpointArgs(value) {
 }
 
 /**
+ * Function to return if source set to amp
+ * @param {string} query param defining name of source
+ * @return {Boolean} returns if source is equal to amp
+ */
+function sanitizeSource(value) {
+  return (value && value.toLowerCase() === 'amp');
+}
+
+/**
  * If the value is a valid sync count (0 or a positive number), return it.
  * Otherwise return a really big integer (equivalent to "no sync").
  */
@@ -239,6 +249,12 @@ function getStringifiedData(endPointArgs) {
 
   if(GDPR) data.gdpr = GDPR;
   if(GDPR_CONSENT) data.gdpr_consent = GDPR_CONSENT;
+  if(IS_AMP) data.filterSettings = {
+    iframe: {
+      bidders: '*',
+      filter: 'exclude'
+    }
+  };
   if(BIDDER_ARGS) data.bidders = BIDDER_ARGS;
 
   return JSON.stringify(data);

--- a/src/cookieSyncWithConsent.js
+++ b/src/cookieSyncWithConsent.js
@@ -16,6 +16,8 @@ const VALID_ENDPOINTS = {
 };
 const ENDPOINT = sanitizeEndpoint(parseQueryParam('endpoint', window.location.search));
 const ENDPOINT_ARGS = sanitizeEndpointArgs(parseQueryParam('args', window.location.search));
+const IS_AMP = sanitizeSource(parseQueryParam('source', window.location.search));
+const BIDDER_ARGS = sanitizeBidders(parseQueryParam('bidders', window.location.search));
 const maxSyncCountParam = parseQueryParam('max_sync_count', window.location.search);
 const MAX_SYNC_COUNT = sanitizeSyncCount(parseInt((maxSyncCountParam) ? maxSyncCountParam : 10, 10));
 const TIMEOUT = sanitizeTimeout(parseInt(parseQueryParam('timeout', window.location.search), 10));
@@ -185,6 +187,15 @@ function sanitizeEndpointArgs(value) {
 }
 
 /**
+ * Function to return if source set to amp
+ * @param {string} query param defining name of source
+ * @return {Boolean} returns if source is equal to amp
+ */
+function sanitizeSource(value) {
+  return (value && value.toLowerCase() === 'amp');
+}
+
+/**
  * If the value is a valid sync count (0 or a positive number), return it.
  * Otherwise return a really big integer (equivalent to "no sync").
  */
@@ -193,6 +204,22 @@ function sanitizeSyncCount(value) {
         return 9007199254740991 // Number.MAX_SAFE_INTEGER isn't supported in IE
     }
     return value;
+}
+
+/**
+ * If the value is a non empty string return it.
+ * Otherwise it will return undefined.
+ */
+function sanitizeBidders(value) {
+  if (value) {
+    var arr = value.split(',');
+    var filtered = arr.filter(function (el) {
+      return (el) ? true : false;
+    });
+    if(filtered.length > 0){
+      return filtered;
+    }
+  }
 }
 
 /**
@@ -239,6 +266,14 @@ function attachConsent(data) {
 function getStringifiedData(endPointArgs) {
     var data = (endPointArgs && typeof endPointArgs === 'object') ? endPointArgs : {}
     data['limit'] = MAX_SYNC_COUNT;
+
+    if(IS_AMP) data.filterSettings = {
+        iframe: {
+            bidders: '*',
+            filter: 'exclude'
+        }
+    };
+    if(BIDDER_ARGS) data.bidders = BIDDER_ARGS;
 
     data = attachConsent(data);
 

--- a/testpages/amp_cookiesync.html
+++ b/testpages/amp_cookiesync.html
@@ -15,7 +15,7 @@
             height="1"
             sandbox="allow-scripts"
             frameborder="0"
-            src="https://localhost:8080/dist/load-cookie.html?max_sync_count=1">
+            src="https://localhost:8080/dist/load-cookie.html?max_sync_count=1&source=amp">
             <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>
         </amp-iframe>
     </body>

--- a/testpages/amp_cookiesync_with_consent.html
+++ b/testpages/amp_cookiesync_with_consent.html
@@ -44,7 +44,7 @@
             height="1"
             sandbox="allow-scripts allow-same-origin allow-popups"
             frameborder="0"
-            src="http://localhost:9990/dist/load-cookie-with-consent.html?max_sync_count=1"
+            src="http://localhost:9990/dist/load-cookie-with-consent.html?max_sync_count=1&source=amp"
             layout="responsive">
             <amp-img layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" placeholder></amp-img>
         </amp-iframe>


### PR DESCRIPTION
- Update to cookieSync/cookieSyncWithConsent to include passing filterSettings to endpoint if query param source === amp

- Update cookieSyncWithConsent to include bidders query param logic. Seems this was an oversight and is missing from the file