### PR TITLE
Static vast tag for mobile rendering API for rewarded video

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,6 +155,11 @@ function buildUid() {
     .pipe(gulp.dest('dist'));
 }
 
+function includeStaticVastXmlFile() {
+  let target = gulp.src('static/prebid-mobile-rewarded-vast.xml');
+  return target.pipe(gulp.dest('dist'));
+}
+
 // Run the unit tests.
 //
 // By default, this runs in headless chrome.
@@ -200,7 +205,7 @@ function setupE2E(done) {
 
 gulp.task('test', gulp.series(clean, test));
 
-gulp.task('e2e-test', gulp.series(clean, setupE2E, gulp.parallel(buildDev, buildCookieSync, buildCookieSyncWithConsent, buildNativeDev, buildNativeRenderDev, buildUidDev, watch), test));
+gulp.task('e2e-test', gulp.series(clean, setupE2E, gulp.parallel(buildDev, buildCookieSync, buildCookieSyncWithConsent, buildNativeDev, buildNativeRenderDev, buildUidDev, includeStaticVastXmlFile, watch), test));
 
 function watch(done) {
   const mainWatcher = gulp.watch([
@@ -215,7 +220,7 @@ function watch(done) {
     root: './'
   });
 
-  mainWatcher.on('all', gulp.series(clean, gulp.parallel(buildDev, buildNativeDev, buildNativeRenderDev, buildCookieSync, buildCookieSyncWithConsent, buildUidDev), test));
+  mainWatcher.on('all', gulp.series(clean, gulp.parallel(buildDev, buildNativeDev, buildNativeRenderDev, buildCookieSync, buildCookieSyncWithConsent, buildUidDev, includeStaticVastXmlFile), test));
   done();
 }
 
@@ -223,9 +228,9 @@ function openWebPage() {
   return opens(`${(argv.https) ? 'https' : 'http'}://localhost:${port}`);
 }
 
-gulp.task('serve', gulp.series(clean, gulp.parallel(buildDev, buildNativeDev, buildNativeRenderDev, buildCookieSync, buildCookieSyncWithConsent, buildUidDev, watch, test), openWebPage));
+gulp.task('serve', gulp.series(clean, gulp.parallel(buildDev, buildNativeDev, buildNativeRenderDev, buildCookieSync, buildCookieSyncWithConsent, buildUidDev, includeStaticVastXmlFile, watch, test), openWebPage));
 
-gulp.task('build', gulp.parallel(buildProd, buildCookieSync, buildCookieSyncWithConsent, buildNative, buildNativeRender, buildUid));
+gulp.task('build', gulp.parallel(buildProd, buildCookieSync, buildCookieSyncWithConsent, buildNative, buildNativeRender, buildUid, includeStaticVastXmlFile));
 
 gulp.task('test-coverage', (done) => {
   new KarmaServer(karmaConfMaker(true, false, false), newKarmaCallback(done)).start();

--- a/static/prebid-mobile-rewarded-vast.xml
+++ b/static/prebid-mobile-rewarded-vast.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST version="2.0">
+   <Ad id="PrebidMobileAppEvent">
+      <InLine>
+         <AdSystem version="1.0">Prebid org</AdSystem>
+         <AdTitle>PrebidAppEvent</AdTitle>
+         <Impression><![CDATA[https://test.url.com]]></Impression>
+         <Creatives>
+            <Creative>
+               <Linear>
+                  <Duration>00:00:02</Duration>
+                  <MediaFiles>
+                     <MediaFile delivery="progressive" height="540" id="539733616" type="video/mp4" width="960">
+                         <![CDATA[https://test.url.com/gam_rewarded.mp4]]>
+                     </MediaFile>
+                  </MediaFiles>
+               </Linear>
+            </Creative>
+         </Creatives>
+      </InLine>
+   </Ad>
+</VAST>


### PR DESCRIPTION
## Motivation

Host a static VAST tag in order to use it instead of PUC in the scenario for integration of the Prebid Mobile Rendering API with GAM Rewarded Video ads.

## Description of the tag

This tag signals the Prebid Mobile SDK that Prebid's Line Item for the Rewarded Video wins. The trigger is a tag

```
<AdTitle>PrebidAppEvent</AdTitle>
```

Based on it the SDK determines a winner and manages to render it.

## Future Steps

Need to host this file in the public space in order to use its URL in the GAM Creative setup.