### PR TITLE
Replace missing native assets with empty strings

### DIFF
--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -70,8 +70,6 @@ export function newNativeAssetManager(win, pubUrl) {
     }
   }
 
-
-
   function getCacheEndpoint(cacheHost, cachePath) {
     let host = (typeof cacheHost === 'undefined' || cacheHost === "") ? DEFAULT_CACHE_HOST : cacheHost;
     let path = (typeof cachePath === 'undefined' || cachePath === "") ? DEFAULT_CACHE_PATH : cachePath;
@@ -336,22 +334,17 @@ export function newNativeAssetManager(win, pubUrl) {
   /**
    * Replaces occurrences of native placeholder values with their actual values
    * in the given document.
-   * If there are still native placeholders in the template that were not replaced (because no asset value was sent),
-   * those placeholders will be replaced by an empty string.
+   * If there's no actual value, the placeholder gets replaced by an empty string.
    */
   function replace(document, { assets, adId }) {
     let html = document;
 
-    (assets || []).forEach(asset => {
-      const flag = pbNativeDataHasValidType();
-      const searchString = (adId && !flag) ? `${NATIVE_KEYS[asset.key]}:${adId}` : ((flag) ? '##'+`${NATIVE_KEYS[asset.key]}`+'##' : `${NATIVE_KEYS[asset.key]}`);
-      const searchStringRegex = new RegExp(searchString, 'g');
-      html = html.replace(searchStringRegex, asset.value);
-    });
-
     scanForPlaceholders().forEach(placeholder => {
-      const searchString = pbNativeDataHasValidType() ? `##${placeholder}##` : placeholder;
-      html = html.replaceAll(searchString, '');
+      const flag = true;
+      const searchString = (adId && !flag) ? `${placeholder}:${adId}` : ((flag) ? '##'+`${placeholder}`+'##' : `${placeholder}`);
+      const searchStringRegex = new RegExp(searchString, 'g');
+      const fittingAsset = assets.find(asset => placeholder === NATIVE_KEYS[asset.key]);
+      html = html.replace(searchStringRegex, fittingAsset ? fittingAsset.value : '');
     })
 
     return html;

--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -340,7 +340,7 @@ export function newNativeAssetManager(win, pubUrl) {
     let html = document;
 
     scanForPlaceholders().forEach(placeholder => {
-      const flag = true;
+      const flag = pbNativeDataHasValidType();
       const searchString = (adId && !flag) ? `${placeholder}:${adId}` : ((flag) ? '##'+`${placeholder}`+'##' : `${placeholder}`);
       const searchStringRegex = new RegExp(searchString, 'g');
       const fittingAsset = assets.find(asset => placeholder === NATIVE_KEYS[asset.key]);


### PR DESCRIPTION
See the following [issue](https://github.com/prebid/Prebid.js/issues/8769) and closed [PR](https://github.com/prebid/Prebid.js/pull/8773) for Prebid.js. 

Instead of replacing missing native assets in Prebid Core, all remaining placeholders in the template are now directly replaced by empty strings in the `nativeAssetManager`. 

After replacing the placeholders with existing assets, all placeholders available in the original template are searched for again and if still found, replaced by an empty string. 

I also extracted the `typeof win.pbNativeData !== 'undefined'` flag to a function. I'm not 100% sure what it does but I suppose it checks if the template is a GAM template? I hope I used it the right way.

Thanks for your review!