### PR TITLE
Remove <!doctype> from markup before rendering with postscribe

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -32,6 +32,9 @@ export function writeAdUrl(adUrl, width, height) {
 }
 
 export function writeAdHtml(markup) {
+  // remove <?xml> and <!doctype> tags
+  // https://github.com/prebid/prebid-universal-creative/issues/134
+  markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[]+(\[[^\]]+)?))+[^>]+\>/g, '');
   postscribe(document.body, markup, {
     error: console.error
   });


### PR DESCRIPTION
Fix for https://github.com/prebid/prebid-universal-creative/issues/134

I was not able to reproduce or test with mobile, but I "cheated" by forcing normal ads to go through postscribe.

