### PR TITLE
Fix issue with native ads being resized incorrectly (1.14 patch)

### DIFF
--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -328,7 +328,7 @@ export function newNativeAssetManager(win, pubUrl) {
       } else if ((data.hasOwnProperty('adTemplate') && data.adTemplate)||(hasPbNativeData() && win.pbNativeData.hasOwnProperty('adTemplate'))) {
         const template =  (hasPbNativeData() && win.pbNativeData.hasOwnProperty('adTemplate') && win.pbNativeData.adTemplate) || data.adTemplate;
         const newHtml = replace(template, data);
-        
+
         renderAd(newHtml, data);
       } else {
         const newHtml = replace(body, data);
@@ -350,7 +350,7 @@ export function newNativeAssetManager(win, pubUrl) {
         if (!currentParentWindow.frames || !currentParentWindow.frames.length) return null;
         for (let idx = 0; idx < currentParentWindow.frames.length; idx++)
             if (currentParentWindow.frames[idx] === currentWindow) {
-              if (!currentParentWindow.document) return null; 
+              if (!currentParentWindow.document) return null;
                 for (let frameElement of currentParentWindow.document.getElementsByTagName('iframe')) {
                     if (!frameElement.contentWindow) return null;
                     if (frameElement.contentWindow === currentWindow) {
@@ -369,14 +369,12 @@ export function newNativeAssetManager(win, pubUrl) {
     if (!envionment.isSafeFrame()) {
       let iframeContainer = getCurrentFrameContainer(win);
       if (iframeContainer && iframeContainer.children && iframeContainer.children[0]) {
-        const iframe = iframeContainer.children[0]; 
+        const iframe = iframeContainer.children[0];
         if (iframe.width === '1' && iframe.height === '1') {
           let width =  iframeContainer.getBoundingClientRect().width;
           win.document.body.style.width = `${width}px`;
         }
       }
-    } else {
-      document.body.style.width = Math.ceil(win.$sf.ext.geom().self.b) + 'px';
     }
     win.document.body.innerHTML += html;
     callback && callback();
@@ -423,7 +421,7 @@ export function newNativeAssetManager(win, pubUrl) {
     if (ortb.link) {
       html = html.replaceAll("##hb_native_linkurl##", ortb.link.url);
     }
-  
+
     return html;
   }
 


### PR DESCRIPTION
Addresses https://github.com/prebid/Prebid.js/issues/9171

This test page shows incorrect rendering on latest (currently 1.14):

```
<html>
<head>
    <script>
        var PREBID_TIMEOUT = 6000;

        var adUnits = [
            {
                code: 'native-div',
                mediaTypes: {
                    native: {
                        adTemplate: `
                                        <div id="adunit" style="overflow: hidden; width: 335px !important;">
                                            <div>Lorem ipsum etcetera Lorem ipsum etcetera Lorem ipsum etcetera Lorem ipsum etcetera Lorem ipsum etcetera Lorem ipsum etcetera Lorem ipsum etcetera</div>
                                            <a style: 'display: block' class="clickUrl" href="##hb_native_linkurl##">
                                              <img class="image" width="400" src="##hb_native_image##" />
                                              <div class="title pb-click" pbAdId="##hb_adid##">##hb_native_title##</div>
                                              <div class="body">##hb_native_body##</div>
                                            </a>
                                        </div>
                                    `,
                        title: {
                            required: true
                        },
                        body: {
                            required: true,
                            sendId: true
                        },
                        image: {
                            required: true
                        },
                        sponsoredBy: {
                            required: true
                        },
                        icon: {
                            required: false
                        }
                    }
                },
                bids: [{
                    bidder: 'appnexus',
                    params: {
                        placementId: 13232354,
                        allowSmallerSizes: true
                    }
                }]
            }];


        var pbjs = pbjs || {};
        pbjs.que = pbjs.que || [];

    </script>
    <!--
    <script type="text/javascript" src="http://lh.rubiconproject.com/prebid/pbjs-native2-beta.js" async></script>

    -->
    <script type="text/javascript" src="../../../build/dev/prebid.js" async></script>

    <script>
        var googletag = googletag || {};
        googletag.cmd = googletag.cmd || [];
        googletag.cmd.push(function() {
            googletag.pubads().disableInitialLoad();
        });

        pbjs.que.push(function() {
            pbjs.setConfig({debug: true});
            pbjs.setConfig({
                debugging: {
                    enabled: true,
                }
            });
            pbjs.addAdUnits(adUnits);
//        pbjs.setConfig({
//	    s2sConfig: {
//		accountId: '1001',
//		bidders: ['appnexus'],
//		endpoint: 'https://prebid-server.dev.rubiconproject.com/openrtb2/auction',
//		syncEndpoint: 'https://prebid-server.rubiconproject.com/cookie_sync',
//		adapter: 'prebidServer',
//		timeout: 1000,
//		enabled: true
//	    }
//	});
            pbjs.requestBids({
                bidsBackHandler: sendAdserverRequest
            });
        });

        function sendAdserverRequest(bids, timedOut, auctionId) {
            if (pbjs.adserverRequestSent) return;
            pbjs.adserverRequestSent = true;
            googletag.cmd.push(function() {
                pbjs.que.push(function() {
                    pbjs.setTargetingForGPTAsync();
                    googletag.pubads().refresh();
                });
            });
        }

        setTimeout(function() {
            sendAdserverRequest();
        }, PREBID_TIMEOUT);
    </script>

    <script>
        (function () {
            var gads = document.createElement('script');
            gads.async = true;
            gads.type = 'text/javascript';
            var useSSL = 'https:' == document.location.protocol;
            gads.src = (useSSL ? 'https:' : 'http:') +
                '//www.googletagservices.com/tag/js/gpt.js';
            var node = document.getElementsByTagName('script')[0];
            node.parentNode.insertBefore(gads, node);
        })();
    </script>

    <script>
        googletag.cmd.push(function() {
            googletag.defineSlot('/41758329/dgirardi-test', ['fluid'], 'native-div').setTargeting("liselect", 'issue-9131').addService(googletag.pubads());
            googletag.pubads().enableSingleRequest();
            googletag.enableServices();
        });
    </script>
</head>

<body>
<h2>Prebid Native Test</h2>

<div id='native-div'>
    <script>
        googletag.cmd.push(function() { googletag.display('native-div'); });
    </script>
</div>
</body>
</html>

```