### PR TITLE
Support for hb_native_privicon macro

### DIFF
--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -16,6 +16,7 @@ const NATIVE_KEYS = {
   body: 'hb_native_body',
   body2: 'hb_native_body2',
   privacyLink: 'hb_native_privacy',
+  privacyIcon: 'hb_native_privicon',
   sponsoredBy: 'hb_native_brand',
   image: 'hb_native_image',
   icon: 'hb_native_icon',

--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -12,6 +12,7 @@ const NATIVE_KEYS = {
   body: 'hb_native_body',
   body2: 'hb_native_body2',
   privacyLink: 'hb_native_privacy',
+  privacyIcon: 'hb_native_privicon',
   sponsoredBy: 'hb_native_brand',
   image: 'hb_native_image',
   icon: 'hb_native_icon',


### PR DESCRIPTION
According to [Prebid.js Native Implementation Guide](https://docs.prebid.org/prebid/native-implementation.html) `privacyIcon` asset code and corresponding `##hb_native_privicon##` macro must be supported by Prebid Universal Creative