### PR TITLE
Add macro to track clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ You can find a detailed explanations on the [Prebid Universal Creative](http://p
   ucTagData.hbPb = "%%PATTERN:hb_pb%%";
   ucTagData.hbFormat = "%%PATTERN:hb_format%%";
   ucTagData.adId = "%%PATTERN:hb_adid%%";
+  // if you're using GAM and want to track outbound clicks on native ads you can add this line
+  ucTagData.clickUrlUnesc = "%%CLICK_URL_UNESC%%";
   ucTagData.requestAllAssets = true;
 
   try {

--- a/src/nativeRenderManager.js
+++ b/src/nativeRenderManager.js
@@ -51,7 +51,7 @@ export function newNativeRenderManager(win) {
   let renderNativeAd = function(doc, nativeTag) {
     window.pbNativeData = nativeTag;
     sendMessage = prebidMessenger(nativeTag.pubUrl, win);
-    const nativeAssetManager = newNativeAssetManager(window, nativeTag.pubUrl);
+    const nativeAssetManager = newNativeAssetManager(window, nativeTag);
 
     if (nativeTag.hasOwnProperty('adId')) {
 

--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -86,7 +86,9 @@ describe('nativeAssetManager', () => {
   let win;
 
   function makeManager() {
-    return newNativeAssetManager(win, ORIGIN);
+    return newNativeAssetManager(win, {
+      pubUrl: ORIGIN
+    });
   }
 
   beforeEach(() => {


### PR DESCRIPTION
In a GAM native ad, if you prepend `%%CLICK_URL_UNESC%%` to links, GAM will also track clicks. 

To use it, the publisher must change the Prebid Universal Creative script like this: 

```
<script>
  var ucTagData = {};
  ucTagData.adId = "%%PATTERN:hb_adid%%";
  ...
  // if you're using GAM and want to track outbound clicks on native ads you can add this line
  ucTagData.clickUrlUnesc = "%%CLICK_URL_UNESC%%";
  ...
  try {
    ucTag.renderAd(document, ucTagData);
  } catch (e) {
    console.log(e);
  }
</script>
```

In the native template code, publisher can prepend this macro to their hb_native_linkurl: 

```
<div>
   ...
   <a href="%%CLICK_URL_UNESC%%##hb_native_linkurl##" target="_blank" />
</div>
```

This PR tries to support many scenarios:
- when the publisher is not using GAM at all, but the creative contains `%%CLICK_URL_UNESC%%`, it will be removed.  
- when the publisher is using a native template in a GAM native ad, the macro will be translated by gam itself. Code shouldn't do anything.
- When the publisher is using adTemplate or custom renderer, PUC will try to substitute the macro with the actual link, if present, otherwise will simply try to remove the macro from the HTML before attaching to the DOM. 