### PR TITLE
Emit AD_RENDER_SUCCEEDED and AD_RENDER_FAILED for native ads

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ function clean() {
 
 /**
  * This generic function will compile the file specified as inputFile and will
- * generate an output file in the build directory. 
+ * generate an output file in the build directory.
  */
 function buildDev({ inputFile, outputFile }) {
   var cloned = _.cloneDeep(webpackConfig);
@@ -234,7 +234,7 @@ function newKarmaCallback(done) {
         process.exit(exitCode);
       }
     }
-  } 
+  }
 }
 
 function setupE2E(done) {
@@ -265,11 +265,7 @@ function watch(done) {
   done();
 }
 
-function openWebPage() {
-  return opens(`${(argv.https) ? 'https' : 'http'}://localhost:${port}`);
-}
-
-gulp.task('serve', gulp.series(clean, gulp.parallel(...buildDevFunctions, watch, test), openWebPage));
+gulp.task('serve', gulp.series(clean, gulp.parallel(...buildDevFunctions, watch, test)));
 
 gulp.task('build-dev', gulp.parallel(...buildDevFunctions));
 

--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -3,7 +3,7 @@ const webpackConf = require('./webpack.conf');
 const karmaConstants = require('karma').constants;
 const path = require('path');
 
-function setBrowsers(karmaConf, browserstack, watchMode) {
+function setBrowsers(karmaConf, browserstack) {
   if (browserstack) {
     karmaConf.browserStack = {
       username: process.env.BROWSERSTACK_USERNAME,
@@ -12,8 +12,6 @@ function setBrowsers(karmaConf, browserstack, watchMode) {
     }
     karmaConf.customLaunchers = require('./browsers.json')
     karmaConf.browsers = Object.keys(karmaConf.customLaunchers);
-  } else if (watchMode) {
-    karmaConf.browsers = ['Chrome'];
   }
 }
 
@@ -29,7 +27,7 @@ function setReporters(karmaConf, codeCoverage, browserstack) {
       suppressPassed: true
     };
   }
-  
+
   if (codeCoverage) {
     karmaConf.reporters.push('coverage-istanbul');
     karmaConf.coverageIstanbulReporter = {
@@ -41,7 +39,7 @@ function setReporters(karmaConf, codeCoverage, browserstack) {
           urlFriendlyName: true, // simply replaces spaces with _ for files/dirs
         }
       }
-    }  
+    }
   }
 }
 
@@ -149,6 +147,6 @@ module.exports = function(codeCoverage, browserstack, watchMode) {
     captureTimeout: 4 * 60 * 1000, // default 60000
   }
   setReporters(config, codeCoverage, browserstack);
-  setBrowsers(config, browserstack, watchMode);
+  setBrowsers(config, browserstack);
   return config;
 }

--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -71,6 +71,7 @@ export function newNativeAssetManager(win, nativeTag, mkMessenger = prebidMessen
     if (nativeTag.clickUrlUnesc && nativeTag.clickUrlUnesc !== CLICK_URL_UNESC) {
       clickUrlUnesc = nativeTag.clickUrlUnesc;
     }
+  const {pubUrl} = nativeTag;
 
   const sendMessage = mkMessenger(pubUrl, win);
   let callback, errCallback;

--- a/src/nativeORTBTrackerManager.js
+++ b/src/nativeORTBTrackerManager.js
@@ -12,11 +12,11 @@ export function fireNativeImpressionTrackers(adId, sendMessage) {
     sendMessage(message);
 }
 
-export function addNativeClickTrackers(adId, ortb, sendMessage) {
+export function addNativeClickTrackers(adId, sendMessage) {
     const message = {
         message: 'Prebid Native',
         action: 'click',
-        adId 
+        adId
       };
     const adElements = document.getElementsByClassName(AD_ANCHOR_CLASS_NAME) || [];
     // get all assets that have 'link' property, map asset.id -> asset.link

--- a/src/nativeRenderManager.js
+++ b/src/nativeRenderManager.js
@@ -24,7 +24,7 @@ export function newNativeRenderManager(win, mkMessenger = prebidMessenger, asset
         try {
             const nativeAssetManager = assetMgr(window, nativeTag);
 
-            if (nativeTag.hasOwnProperty('adId')) {
+            if (nativeTag.adId != null) {
 
                 if (nativeTag.hasOwnProperty('rendererUrl') && !nativeTag.rendererUrl.match(/##.*##/i)) {
                     const scr = doc.createElement('SCRIPT');

--- a/src/nativeRenderManager.js
+++ b/src/nativeRenderManager.js
@@ -1,76 +1,53 @@
 /*
  * Script to handle firing impression and click trackers from native teamplates
  */
-import { newNativeAssetManager } from './nativeAssetManager';
+import {newNativeAssetManager} from './nativeAssetManager';
 import {prebidMessenger} from './messaging.js';
 
-const AD_ANCHOR_CLASS_NAME = 'pb-click';
-const AD_DATA_ADID_ATTRIBUTE = 'pbAdId';
-
-export function newNativeRenderManager(win) {
-  let sendMessage;
+export function newNativeRenderManager(win, mkMessenger = prebidMessenger, assetMgr = newNativeAssetManager) {
+    let sendMessage;
 
 
-  function findAdElements(className) {
-    let adElements = win.document.getElementsByClassName(className);
-    return adElements || [];
-  }
+    let renderNativeAd = function (doc, nativeTag) {
+        window.pbNativeData = nativeTag;
+        sendMessage = mkMessenger(nativeTag.pubUrl, win);
 
-  function loadClickTrackers(event, adId) {
-    fireTracker(adId, 'click');
-  }
+        function signalResult(adId, success, info) {
+            sendMessage({
+                message: 'Prebid Event',
+                adId,
+                event: success ? 'adRenderSucceeded' : 'adRenderFailed',
+                info
+            });
+        }
 
-  function fireTracker(adId, action) {
-    if (adId === '') {
-      console.warn('Prebid tracking event was missing \'adId\'.  Was adId macro set in the HTML attribute ' + AD_DATA_ADID_ATTRIBUTE + 'on the ad\'s anchor element');
-    } else {
-      let message = { message: 'Prebid Native', adId: adId };
+        try {
+            const nativeAssetManager = assetMgr(window, nativeTag.pubUrl);
 
-      // fires click trackers when called via link
-      if (action === 'click') {
-        message.action = 'click';
-      }
-      sendMessage(message);
-    }
-  }
+            if (nativeTag.adId != null) {
 
-  function fireNativeImpTracker(adId) {
-    fireTracker(adId, 'impression');
-  }
+                if (nativeTag.hasOwnProperty('rendererUrl') && !nativeTag.rendererUrl.match(/##.*##/i)) {
+                    const scr = doc.createElement('SCRIPT');
+                    scr.src = nativeTag.rendererUrl,
+                        scr.id = 'pb-native-renderer';
+                    doc.body.appendChild(scr);
+                }
+                nativeAssetManager.loadAssets(nativeTag.adId, () => {
+                    signalResult(nativeTag.adId, true);
+                }, (e) => {
+                    signalResult(nativeTag.adId, false, {reason: 'exception', message: e.message});
+                });
+            } else {
+                signalResult(null, false, {reason: 'missingDocOrAdid'});
+                console.warn('Prebid Native Tag object was missing \'adId\'.');
+            }
+        } catch (e) {
+            signalResult(nativeTag && nativeTag.adId, false, {reason: 'exception', message: e.message});
+            console.error('Error rendering ad', e);
+        }
+    };
 
-  function fireNativeCallback() {
-    const adElements = findAdElements(AD_ANCHOR_CLASS_NAME);
-    for (let i = 0; i < adElements.length; i++) {
-      adElements[i].addEventListener('click', function(event) {
-        loadClickTrackers(event, window.pbNativeData.adId);
-      }, true);
-    }
-  }
-
-  // START OF MAIN CODE
-  let renderNativeAd = function(doc, nativeTag) {
-    window.pbNativeData = nativeTag;
-    sendMessage = prebidMessenger(nativeTag.pubUrl, win);
-    const nativeAssetManager = newNativeAssetManager(window, nativeTag.pubUrl);
-
-    if (nativeTag.hasOwnProperty('adId')) {
-
-      if (nativeTag.hasOwnProperty('rendererUrl') && !nativeTag.rendererUrl.match(/##.*##/i)) {
-        const scr = doc.createElement('SCRIPT');
-        scr.src = nativeTag.rendererUrl,
-        scr.id = 'pb-native-renderer';
-        doc.body.appendChild(scr);
-      }
-      nativeAssetManager.loadAssets(nativeTag.adId, () => {
-        fireNativeImpTracker(nativeTag.adId);
-        fireNativeCallback();
-      });
-    } else {
-      console.warn("Prebid Native Tag object was missing 'adId'.");
-    }
-  }
-
-  return {
-    renderNativeAd
-  }
+    return {
+        renderNativeAd
+    };
 }

--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -631,7 +631,7 @@ describe('nativeAssetManager', () => {
                 beforeEach(() => {
                     win.pbNativeData = pbData;
                     win.document.body.innerHTML = '##hb_native_title##';
-                    mgr = makeManager(mockMessenger);
+                    mgr = makeManager({}, mockMessenger);
                 });
 
                 it('on response "timeout"', () => {

--- a/test/spec/nativeORTBTrackerManager_spec.js
+++ b/test/spec/nativeORTBTrackerManager_spec.js
@@ -37,40 +37,24 @@ describe('test firing native trackers', function () {
 
 
   it('should fire impression trackers', function () {
-    let imgUrl = 'foo.bar/event?type=img';
-    let jsUrl = 'foo.bar/event?type=js';
-    
-
     fireNativeImpressionTrackers("abc123", sendMessage);
 
     expect(sendMessage.getCall(0).args[0]).to.deep.equal({
-      message: 'Prebid Native', 
+      message: 'Prebid Native',
       action: 'fireNativeImpressionTrackers',
       adId: 'abc123'
     })
   });
 
   it('should fire asset clicktrackers', function () {
-    let assetTrackers = ['foo.bar/click?id=1', 'foo.bar/click?id=2'];
-    let mainTrackers = ['foo.bar/click?id=3'];
     let adId = "abc123";
-    let nativeOrtb = {
-      assets: [{
-        id: 1,
-        link: { clicktrackers: assetTrackers }
-      }],
-      link: {
-        clicktrackers: mainTrackers
-      }
-    }
-
-    addNativeClickTrackers(adId, nativeOrtb, sendMessage);
+    addNativeClickTrackers(adId, sendMessage);
     expect(sendMessage.getCall(0).args[0]).to.deep.equal({
       message: "Prebid Native",
       action: 'click',
       adId: 'abc123',
       assetId: 1
     });
-    
+
   });
 });

--- a/test/spec/nativeRenderManager_spec.js
+++ b/test/spec/nativeRenderManager_spec.js
@@ -1,8 +1,7 @@
-import { newNativeRenderManager } from 'src/nativeRenderManager';
-import * as nam  from 'src/nativeAssetManager';
-import { expect } from 'chai';
-import { mocks } from 'test/helpers/mocks';
-import { merge } from 'lodash';
+import {newNativeRenderManager} from 'src/nativeRenderManager';
+import * as nam from 'src/nativeAssetManager';
+import {mocks} from 'test/helpers/mocks';
+import {merge} from 'lodash';
 
 const renderingMocks = {
   getWindowObject: function() {
@@ -14,10 +13,6 @@ const renderingMocks = {
     }
   }
 };
-
-function trimPort(url) {
-  return ((/:\d+/).test(url)) ? url.substring(0, url.lastIndexOf(':')) : url;
-}
 
 describe('nativeRenderManager', function () {
   describe('load renderNativeAd', function () {
@@ -55,57 +50,83 @@ describe('nativeRenderManager', function () {
       assetManagerStub.restore();
     });
 
-    it("should verify the postMessage for impression trackers was executed", function () {
-      mockWin.document.getElementsByClassName = () => [
-        {
-          attributes: {
-            pbAdId: {
-              value: "ad123",
-            },
-          },
-          addEventListener: (type, listener, capture) => {},
-        },
-      ];
-      let nativeTracker = new newNativeRenderManager(mockWin);
-      nativeTracker.renderNativeAd(mockWin.document, tagData);
+    describe('should fire event', () => {
+      let recvMessages;
+      function mockMessenger() {
+        return recvMessages.push.bind(recvMessages);
+      }
 
-      expect(mockWin.parent.postMessage.callCount).to.equal(1);
-      let postMessageTargetDomain = mockWin.parent.postMessage.args[0][1];
-      let postMessageContents = mockWin.parent.postMessage.args[0][0];
-      let rawPostMessage = JSON.parse(postMessageContents);
-
-      expect(rawPostMessage.message).to.exist.and.to.equal("Prebid Native");
-      expect(rawPostMessage.adId).to.exist.and.to.equal("ad123");
-      expect(rawPostMessage.action).to.not.exist;
-      expect(trimPort(postMessageTargetDomain)).to.equal(tagData.pubUrl);
-    });
-
-    it('should verify the postMessages for the impression and click trackers were executed', function() {
-      mockWin.document.getElementsByClassName = () => [{
-        attributes: {
-          pbAdId: {
-            value: 'ad123'
+      beforeEach(() => {
+        recvMessages = [];
+      });
+      it('AD_RENDER_SUCCEEDED', () => {
+        const mockAssetMgr = function () {
+          return {
+            loadAssets(_, fn) {
+              fn();
+            }
           }
-        },
-        addEventListener: ((type, listener, capture) => {
-          listener({
+        }
+        const rdr = newNativeRenderManager(mockWin, mockMessenger, mockAssetMgr);
+        rdr.renderNativeAd(mockWin.document, tagData);
+        sinon.assert.match(recvMessages[0], {
+          message: 'Prebid Event',
+          adId: 'ad123',
+          event: 'adRenderSucceeded',
+        })
+      })
+      describe('AD_RENDER_FAILED', () => {
+        it('on exceptions', () => {
+          const rdr = newNativeRenderManager(mockWin, mockMessenger);
+          rdr.renderNativeAd(mockWin.document, Object.defineProperties({...tagData}, {
+            rendererUrl: {
+              get() {
+                throw new Error('err');
+              }
+            }
+          }));
+          sinon.assert.match(recvMessages[0], {
+            message: 'Prebid Event',
+            adId: 'ad123',
+            event: 'adRenderFailed',
+            info: {
+              reason: 'exception',
+              message: 'err'
+            }
+          })
+        });
+        it('on missing adId',() => {
+          const rdr = newNativeRenderManager(mockWin, mockMessenger);
+          rdr.renderNativeAd(mockWin.document, {...tagData, adId: undefined});
+          sinon.assert.match(recvMessages[0], {
+            message: 'Prebid Event',
+            event: 'adRenderFailed',
+            info: {
+              reason: 'missingDocOrAdid',
+            }
+          })
+        });
+        it('on rendering errors', () => {
+          const mockAssetMgr = function () {
+            return {
+              loadAssets(_1, _2, err) {
+                err(new Error('err'))
+              }
+            }
+          }
+          const rdr = newNativeRenderManager(mockWin, mockMessenger, mockAssetMgr);
+          rdr.renderNativeAd(mockWin.document, tagData);
+          sinon.assert.match(recvMessages[0], {
+            message: 'Prebid Event',
+            event: 'adRenderFailed',
+            info: {
+              reason: 'exception',
+              message: 'err'
+            }
           })
         })
-      }];
-
-      let nativeTracker = new newNativeRenderManager(mockWin);
-      nativeTracker.renderNativeAd(mockWin.document, tagData);
-
-      expect(mockWin.parent.postMessage.callCount).to.equal(2);
-
-      let postMessageTargetDomain = mockWin.parent.postMessage.args[0][1];
-      let postMessageContents = mockWin.parent.postMessage.args[1][0];
-      let rawPostMessage = JSON.parse(postMessageContents);
-
-      expect(rawPostMessage.message).to.exist.and.to.equal("Prebid Native");
-      expect(rawPostMessage.adId).to.exist.and.to.equal("ad123");
-      expect(rawPostMessage.action).to.exist.and.to.equal('click');
-      expect(trimPort(postMessageTargetDomain)).to.equal(tagData.pubUrl);
+      })
     });
   });
+
 });


### PR DESCRIPTION
Update native rendering logic to signal AD_RENDER_SUCCEEDED and AD_RENDER_FAILED events to Prebid.

