### PR TITLE
Replace all placeholders with the corresponding ortb assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Universal creative for Prebid apps",
     "main": "dist/creative.js",
     "scripts": {
-        "test": "echo test",
+        "test": "gulp test",
         "prepublish": "gulp build"
     },
     "repository": {

--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -426,16 +426,16 @@ export function newNativeAssetManager(win, nativeTag) {
     }
 
     ortb.assets.forEach(asset => {
-      html = html.replace(`##hb_native_asset_id_${asset.id}##`, getAssetValue(asset));
+      html = html.replaceAll(`##hb_native_asset_id_${asset.id}##`, getAssetValue(asset));
       if (asset.link && asset.link.url) {
-        html = html.replace(`##hb_native_asset_link_id_${asset.id}##`, asset.link.url);
+        html = html.replaceAll(`##hb_native_asset_link_id_${asset.id}##`, asset.link.url);
       }
     });
 
     html = html.replaceAll(/##hb_native_asset_id_\d+##/gm, '');
 
     if (ortb.privacy) {
-      html = html.replace("##hb_native_privacy##", ortb.privacy);
+      html = html.replaceAll("##hb_native_privacy##", ortb.privacy);
     }
 
     if (ortb.link) {

--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -357,6 +357,7 @@ describe('nativeAssetManager', () => {
       <div class="attribution">
         <img class="pb-icon" src="##hb_native_asset_id_3##" alt="icon" height="150" width="50">
       </div>
+      <h2>##hb_native_asset_id_1##</h2>
       <p>##hb_native_asset_id_4##</p>
     </div>
   </div>
@@ -415,6 +416,9 @@ describe('nativeAssetManager', () => {
       // ##hb_native_asset_id_4## was not returned in the response, it should 
       // be transformed into an empty string
       expect(win.document.body.innerHTML).to.not.include(`##hb_native_asset_id_4##`);
+
+      // test that we are replacing ALL asset occurrences
+      expect(([...win.document.body.innerHTML.match(/new value/g)] || []).length, "expected 2 occurrences of \"new value\"").to.equal(2);
     });
   
     it('no placeholders found but requests all assets flag set - adTemplate', () => {


### PR DESCRIPTION
At the moment **only the first occurrence** of an ortb placeholder **is replaced by the asset value**, the second one will be replaced by an empty string. 

I found this issue because our native design template uses the same placeholder twice for responsiveness reasons. Depending on the viewport size, one of them has the CSS property `display: none` but they are both present in the template. When the second occurrence gets displayed, the html element is always empty - I would expect all placeholders with the corresponding asset id to be replaced though.

Thank you for checking! 😊