### PR TITLE
Log error when renderAd lookup failed

### DIFF
--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -19,17 +19,22 @@ export function renderBannerOrDisplayAd(doc, dataObject) {
  * @param {string} adId Id of creative to render
  */
 export function renderLegacy(doc, adId) {
+  let found = false;
   let w = window;
   for (let i = 0; i < 10; i++) {
     w = w.parent;
     if (w.$$PREBID_GLOBAL$$) {
       try {
+        found = true;
         w.$$PREBID_GLOBAL$$.renderAd(doc, adId);
         break;
       } catch (e) {
         continue;
       }
     }
+  }
+  if (!found) {
+    console.error("Unable to locate $$PREBID_GLOBAL$$.renderAd function!");
   }
 }
 


### PR DESCRIPTION
When the universal creative fails to find the `renderAd` function, it silently continues, resulting in a failed ad render not being noticeable in the console. This adds an error message when it happens.