### PR TITLE
Set found after renderAd call

### DIFF
--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -25,8 +25,8 @@ export function renderLegacy(doc, adId) {
     w = w.parent;
     if (w.$$PREBID_GLOBAL$$) {
       try {
-        found = true;
         w.$$PREBID_GLOBAL$$.renderAd(doc, adId);
+        found = true;
         break;
       } catch (e) {
         continue;


### PR DESCRIPTION
Resolves the issue of no error when prebid global is defined but not renderAd.