### PR TITLE
Look for tagged ancestors for cross-frame messages

### DIFF
--- a/src/messaging.js
+++ b/src/messaging.js
@@ -9,6 +9,14 @@ export function prebidMessenger(publisherURL, win = window) {
         return parsedUrl.protocol + '://' + parsedUrl.host;
     })();
 
+    function isPrebidWindow(win) {
+        return win && win.frames && win.frames.__pb_locator__;
+    }
+
+    let target = win.parent;
+    while (target != null && target !== win.top && !isPrebidWindow(target)) target = target.parent;
+    if (!isPrebidWindow(target)) target = win.parent;
+
     return function sendMessage(message, onResponse) {
         if (prebidDomain == null) {
             throw new Error('Missing pubUrl')
@@ -16,13 +24,13 @@ export function prebidMessenger(publisherURL, win = window) {
         message = JSON.stringify(message);
         let messagePort;
         if (onResponse == null) {
-            win.parent.postMessage(message, prebidDomain);
+            target.postMessage(message, prebidDomain);
         } else {
             const channel = new MessageChannel();
             messagePort = channel.port1;
             messagePort.onmessage = onResponse;
             win.addEventListener('message', windowListener);
-            win.parent.postMessage(message, prebidDomain, [channel.port2]);
+            target.postMessage(message, prebidDomain, [channel.port2]);
         }
 
         return function stopListening() {

--- a/test/helpers/mocks.js
+++ b/test/helpers/mocks.js
@@ -14,6 +14,7 @@ export const mocks = {
       },
       parent: {},
       top: {},
+      frames: {},
     };
   }
 }

--- a/test/spec/messaging_spec.js
+++ b/test/spec/messaging_spec.js
@@ -25,7 +25,6 @@ describe('prebidMessenger',() => {
     describe('when publisher URL is available', () => {
         const URL = 'https://www.publisher.com/page.html';
         const ORIGIN = 'https://www.publisher.com'
-        let sendMessage;
         let callback, handler;
 
         beforeEach(() => {
@@ -33,13 +32,56 @@ describe('prebidMessenger',() => {
                 handler = h;
             }
             win.removeEventListener = sinon.spy();
-            sendMessage = prebidMessenger(URL, win);
             callback = sinon.spy();
         })
+
+        function sendMessage(...args) {
+            return prebidMessenger(URL, win)(...args);
+        }
 
         it('should use origin for postMessage', () => {
            sendMessage('test');
            sinon.assert.calledWith(win.parent.postMessage, JSON.stringify('test'), ORIGIN);
+        });
+
+        describe('when window has multiple ancestors', () => {
+            let target;
+            beforeEach(() => {
+                const top = mocks.createFakeWindow('top');
+                target = {
+                    ...win.parent,
+                    frames: {},
+                    parent: {
+                        top,
+                        frames: {},
+                        parent: top
+                    }
+                };
+                win = {
+                    top,
+                    frames: {},
+                    parent: {
+                        top,
+                        frames: {},
+                        parent: target
+                    }
+                };
+            })
+            it('should post to first ancestor that has a __pb_locator__ child', () => {
+                [target, target.parent].forEach(win => {
+                    win.frames = {
+                        __pb_locator__: {}
+                    };
+                })
+                sendMessage('test');
+                sinon.assert.calledWith(target.postMessage);
+            });
+            it('should post to immediate parent when no ancestor has __pb_locator__', () => {
+                win.parent.postMessage = sinon.spy();
+                delete target.postMessage;
+                sendMessage('test');
+                sinon.assert.calledWith(win.parent.postMessage);
+            });
         });
 
         it('should not run callback on response if origin does not mach', ()=> {


### PR DESCRIPTION
With https://github.com/prebid/Prebid.js/pull/11863, prebid marks its window with a named frame (to allow for situations when the creative runs in nested iframes). This updates the messaging logic to look for it.

