### PR TITLE
Fix mobile-app rendering when admarkup contains lowercase DOCTYPE tag

### DIFF
--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -3,7 +3,7 @@ import postscribe from 'postscribe';
 export function writeAdHtml(markup, ps = postscribe) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[]+(\[[^\]]+)?))+[^>]+\>/g, '');
+    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[]+(\[[^\]]+)?))+[^>]+\>/gi, '');
     ps(document.body, markup, {
         error: console.error
     });

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -312,5 +312,11 @@ describe('writeAdHtml', () => {
     const ps = sinon.stub();
     writeAdHtml('<!DOCTYPE html><div>mock-ad</div>', ps);
     sinon.assert.calledWith(ps, sinon.match.any, '<div>mock-ad</div>')
-  })
+  });
+
+  it('removes lowercase doctype from markup', () => {
+    const ps = sinon.stub();
+    writeAdHtml('<!doctype html><div>mock-ad</div>', ps);
+    sinon.assert.calledWith(ps, sinon.match.any, '<div>mock-ad</div>')
+  });
 })


### PR DESCRIPTION
Admarkup containing an html DOCTYPE tag `<!DOCTYPE html>` prevents rendering with postscribe.

The uppercase tag did get removed since https://github.com/prebid/prebid-universal-creative/pull/210, but the lowercase `<!doctype html>` (which [is valid HTML](https://html.spec.whatwg.org/multipage/syntax.html#the-doctype)) did not get removed. Now it does by making the regular expression case-insensitive.

This came about because ad markup returned by Amazon APS bids uses lowercase doctype.