### PR TITLE
Require `rendererVersion` >= 3 to use dynamic renderers

### DIFF
--- a/src/dynamicRenderer.js
+++ b/src/dynamicRenderer.js
@@ -1,6 +1,12 @@
 import {makeIframe} from './domHelper.js';
 import {renderEventMessage} from './messaging.js';
 
+export const MIN_RENDERER_VERSION = 3;
+
+export function hasDynamicRenderer(message) {
+    return typeof message.renderer === 'string' && parseInt(message.rendererVersion, 10) >= MIN_RENDERER_VERSION
+}
+
 export function runDynamicRenderer(adId, data, sendMessage, win = window, mkFrame = makeIframe) {
     const renderer = mkFrame(win.document, {
         width: 0,

--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -7,7 +7,7 @@ import { addNativeClickTrackers, fireNativeImpressionTrackers } from './nativeOR
 import { sendRequest, loadScript } from './utils';
 import {prebidMessenger} from './messaging.js';
 import { isSafeFrame } from './environment.js';
-import {runDynamicRenderer} from './dynamicRenderer.js';
+import {hasDynamicRenderer, runDynamicRenderer} from './dynamicRenderer.js';
 /*
  * Native asset->key mapping from Prebid.js/src/constants.json
  * https://github.com/prebid/Prebid.js/blob/8635c91942de9df4ec236672c39b19448545a812/src/constants.json#L67
@@ -309,9 +309,7 @@ export function newNativeAssetManager(win, nativeTag, mkMessenger = prebidMessen
         }
 
         if (data.message === 'assetResponse' && data.adId === adId) {
-          if(data.renderer && parseInt(data.rendererVersion, 10) >= 2) {
-            // only use renderer if it declares version > 2
-            // see https://github.com/prebid/Prebid.js/pull/12655
+          if(hasDynamicRenderer(data)) {
             runDynamicRenderer(adId, data, sendMessage, win);
             return;
           }

--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -2,7 +2,7 @@ import { parseUrl, transformAuctionTargetingData } from './utils';
 import { canLocatePrebid } from './environment';
 import { insertElement, getEmptyIframe } from './domHelper';
 import {prebidMessenger, renderEventMessage} from './messaging.js';
-import {runDynamicRenderer} from './dynamicRenderer.js';
+import {hasDynamicRenderer, runDynamicRenderer} from './dynamicRenderer.js';
 
 export function renderBannerOrDisplayAd(doc, dataObject) {
   const targetingData = transformAuctionTargetingData(dataObject);
@@ -66,7 +66,7 @@ export function renderCrossDomain(win, adId, pubAdServerDomain = '', pubUrl) {
       adObject.message === "Prebid Response" &&
       adObject.adId === adId
     ) {
-      if (adObject.renderer) {
+      if (hasDynamicRenderer(adObject)) {
         runDynamicRenderer(adId, adObject, sendMessage, win);
         return;
       }

--- a/test/spec/dynamicRenderer_spec.js
+++ b/test/spec/dynamicRenderer_spec.js
@@ -1,6 +1,30 @@
 import {makeIframe} from '../../src/domHelper.js';
-import {runDynamicRenderer} from '../../src/dynamicRenderer.js';
+import {hasDynamicRenderer, MIN_RENDERER_VERSION, runDynamicRenderer} from '../../src/dynamicRenderer.js';
 import {AD_RENDER_FAILED, AD_RENDER_SUCCEEDED, PREBID_EVENT} from '../../src/messaging.js';
+
+describe('hasDynamicRenderer', () => {
+    Object.entries({
+        'neither': {},
+        'renderer, but no version': {
+            renderer: 'mock-renderer'
+        },
+        'renderer, but version is too low': {
+            renderer: 'mock-renderer',
+            rendererVersion: 1
+        },
+    }).forEach(([t, data]) => {
+        it(`returns false with ${t}`, () => {
+            expect(hasDynamicRenderer(data)).to.be.false;
+        })
+    });
+
+    it('returns true when both renderer and version are present', () => {
+        expect(hasDynamicRenderer({
+            renderer: 'mock-renderer',
+            rendererVersion: MIN_RENDERER_VERSION
+        })).to.be.true;
+    })
+})
 
 describe('runDynamicRenderer', () => {
     let sendMessage, frame, render;

--- a/test/spec/renderingManager_spec.js
+++ b/test/spec/renderingManager_spec.js
@@ -5,6 +5,7 @@ import * as dynamic from 'src/dynamicRenderer.js';
 import { expect } from 'chai';
 import { mocks } from 'test/helpers/mocks';
 import { merge } from 'lodash';
+import {MIN_RENDERER_VERSION} from "src/dynamicRenderer.js";
 
 function renderingMocks() {
   return {
@@ -120,6 +121,7 @@ describe('renderingManager', function() {
       const data = {
         adId: '123',
         renderer: 'mock-renderer',
+        rendererVersion: MIN_RENDERER_VERSION,
         ad: 'markup'
       };
       mockPrebidResponse(data);


### PR DESCRIPTION
Require dynamic renderers to declare version >= 3 - see https://github.com/prebid/Prebid.js/pull/12699