### PR TITLE
fix for code scanning alert no. 14: Inefficient regular expression

### DIFF
--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -1,7 +1,7 @@
 export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTML.bind(document.body)) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[]+(\[[^\]]+)?))+[^>]+\>/gi, '');
+    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>]+\>/gi, '');
 
     try {
         insertHTML('beforeend', markup);

--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -1,7 +1,7 @@
 export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTML.bind(document.body)) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s]+[^\>]*\>/gi, '');
+    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s\>]+[^\>]*\>/gi, '');
 
     try {
         insertHTML('beforeend', markup);

--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -1,7 +1,6 @@
 export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTML.bind(document.body)) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s>]*?\>/gi, '');
     markup = markup.replace(/<\?xml.*?\?>|<!DOCTYPE[^>]*>/gi, '');
 
     try {

--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -1,7 +1,7 @@
 export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTML.bind(document.body)) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s>]+[^\>\[\s]*\>/gi, '');
+    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s>]*?\>/gi, '');
 
     try {
         insertHTML('beforeend', markup);

--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -1,7 +1,7 @@
 export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTML.bind(document.body)) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s\>]+[^\>\[\s]*\>/gi, '');
+    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s>]+[^\>\[\s]*\>/gi, '');
 
     try {
         insertHTML('beforeend', markup);

--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -1,7 +1,7 @@
 export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTML.bind(document.body)) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>]+\>/gi, '');
+    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s]+[^\>]*\>/gi, '');
 
     try {
         insertHTML('beforeend', markup);

--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -1,7 +1,7 @@
 export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTML.bind(document.body)) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/<\?xml.*?\?>|<!DOCTYPE[^>]*>/gi, '');
+    markup = markup.replace(/<(?:\?xml|!doctype)[^>]*>/gi, '');
 
     try {
         insertHTML('beforeend', markup);

--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -1,7 +1,7 @@
 export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTML.bind(document.body)) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s\>]+[^\>]*\>/gi, '');
+    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s\>]+[^\>\[\s]*\>/gi, '');
 
     try {
         insertHTML('beforeend', markup);

--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -2,6 +2,7 @@ export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTM
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
     markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[\s]+(\[[^\]\s]+\])?))+[^\>\[\s>]*?\>/gi, '');
+    markup = markup.replace(/<\?xml.*?\?>|<!DOCTYPE[^>]*>/gi, '');
 
     try {
         insertHTML('beforeend', markup);


### PR DESCRIPTION
Potential fix for [https://github.com/prebid/prebid-universal-creative/security/code-scanning/14](https://github.com/prebid/prebid-universal-creative/security/code-scanning/14)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. This can be achieved by making the sub-expressions more specific and reducing the potential for multiple matching paths. Specifically, we can replace the ambiguous sub-expression `[^\]]+` with a more precise pattern that avoids nested quantifiers and ambiguity.

The best way to fix the problem without changing existing functionality is to rewrite the regular expression to ensure that each part of the pattern is unambiguous. This involves breaking down the pattern into more specific components and avoiding nested quantifiers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

fixes #175  - robot changes were replaced by human :)
