### PR TITLE
automated pr: Incomplete URL substring sanitization in amp unit test

### DIFF
--- a/integ-test/spec/amp_spec.js
+++ b/integ-test/spec/amp_spec.js
@@ -32,7 +32,11 @@ test.describe('AMP', () => {
                 })
             })
         });
-        await page.route((u) => u.host.startsWith(CACHE_HOST) && u.pathname === CACHE_PATH, (route) => {
+        await page.route((u) => {
+            const host = new URL(u.href).host;
+            const allowedHosts = [CACHE_HOST];
+            return allowedHosts.includes(host) && u.pathname === CACHE_PATH;
+        }, (route) => {
             route.fulfill({
                 contentType: 'application/json',
                 body: JSON.stringify(imp)


### PR DESCRIPTION
Potential fix for [https://github.com/prebid/prebid-universal-creative/security/code-scanning/15](https://github.com/prebid/prebid-universal-creative/security/code-scanning/15)

To fix the problem, we need to replace the substring check with an explicit whitelist of allowed hosts. This ensures that only the exact allowed hosts are accepted, preventing any bypass through malicious URLs.

- Parse the URL to extract the host.
- Use an explicit whitelist to check if the host is allowed.
- Update the relevant code in the file `integ-test/spec/amp_spec.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


fixes #266 