### PR TITLE
Resolve issue where scripts in markup never execute on mobile

### DIFF
--- a/src/adHtmlRender.js
+++ b/src/adHtmlRender.js
@@ -1,10 +1,14 @@
-export function writeAdHtml(markup, insertHTML = document.body.insertAdjacentHTML.bind(document.body)) {
+export function writeAdHtml(markup, insertHTML = appendToBody) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
     markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[]+(\[[^\]]+)?))+[^>]+\>/gi, '');
+    insertHTML(markup);
+}
 
+function appendToBody(html) {
     try {
-        insertHTML('beforeend', markup);
+        const fragment = document.createRange().createContextualFragment(html);
+        document.body.append(fragment);
     } catch (error) {
         console.error(error);
     }

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -287,12 +287,12 @@ describe('writeAdHtml', () => {
   it('removes DOCTYPE from markup', () => {
     const ps = sinon.stub();
     writeAdHtml('<!DOCTYPE html><div>mock-ad</div>', ps);
-    sinon.assert.calledWith(ps, sinon.match.any, '<div>mock-ad</div>')
+    sinon.assert.calledWith(ps, '<div>mock-ad</div>')
   });
 
   it('removes lowercase doctype from markup', () => {
     const ps = sinon.stub();
     writeAdHtml('<!doctype html><div>mock-ad</div>', ps);
-    sinon.assert.calledWith(ps, sinon.match.any, '<div>mock-ad</div>')
+    sinon.assert.calledWith(ps, '<div>mock-ad</div>')
   });
 })

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -284,6 +284,11 @@ describe("renderingManager", function () {
 });
 
 describe('writeAdHtml', () => {
+
+  afterEach(() => {
+    window.testScriptExecuted = undefined;
+  });
+
   it('removes DOCTYPE from markup', () => {
     const ps = sinon.stub();
     writeAdHtml('<!DOCTYPE html><div>mock-ad</div>', ps);
@@ -294,5 +299,11 @@ describe('writeAdHtml', () => {
     const ps = sinon.stub();
     writeAdHtml('<!doctype html><div>mock-ad</div>', ps);
     sinon.assert.calledWith(ps, '<div>mock-ad</div>')
+  });
+
+  it('should execute script tag inserted into the body', () => {
+    const markup = '<script>window.testScriptExecuted=true;</script>'
+    writeAdHtml(markup);
+    expect(window.testScriptExecuted).to.equal(true);
   });
 })


### PR DESCRIPTION
After merging #246, the scripts inside the markup stopped executing because of `insertAdjacentHTML` behavior. This PR aims to fix this issue.