### PR TITLE
Fix: single quoted html attributes are incorrectly parsed by prescribe/postscribe

### DIFF
--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -4,7 +4,41 @@ export function writeAdHtml(markup, ps = postscribe) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
     markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[]+(\[[^\]]+)?))+[^>]+\>/gi, '');
+
+    try {
+        markup = normalizeMarkup(markup);
+    } catch (error) {
+        console.error("Error normalizing markup:", error.message);
+    }
+
     ps(document.body, markup, {
         error: console.error
     });
+}
+
+/**
+ * Normalizes an HTML string by parsing and re-serializing it,
+ * returning the content between custom PUC_START and PUC_END markers.
+ *
+ * This function is specifically aimed at addressing an issue with `postscribe` where double quotes inside single-quoted
+ * HTML attributes are not correctly escaped.
+ */
+ function normalizeMarkup(markup) {
+    const startMarker = '<div id="PUC_START"></div>';
+    const endMarker = '<div id="PUC_END"></div>';
+
+    const wrapped = `${startMarker}${markup}${endMarker}`;
+
+    const doc = new DOMParser().parseFromString(wrapped, "text/html");
+    const serialized = new XMLSerializer().serializeToString(doc);
+
+    const startIndex = serialized.indexOf(startMarker);
+    const endIndex = serialized.indexOf(endMarker, startIndex);
+
+    if (startIndex === -1 || endIndex === -1) {
+        throw new Error("PUC markers not found in serialized output");
+    }
+
+    const snippet = serialized.substring(startIndex + startMarker.length, endIndex);
+    return snippet.trim();
 }

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -4,7 +4,7 @@ import * as utils from 'src/utils';
 import { expect } from 'chai';
 import { mocks } from 'test/helpers/mocks';
 import { merge } from 'lodash';
-import {writeAdHtml} from 'src/postscribeRender';
+import { writeAdHtml } from 'src/postscribeRender';
 
 
 function renderingMocks() {
@@ -305,5 +305,40 @@ describe('writeAdHtml', () => {
     const markup = '<script>window.testScriptExecuted=true;</script>'
     writeAdHtml(markup);
     expect(window.testScriptExecuted).to.equal(true);
+  });
+
+  it('should handle single quotes with inner double quotes', () => {
+    const input = `<img title='uh "oh" > this should all be inside the title attribute'>`;
+    console.log('Input: ', input);
+
+    writeAdHtml(input);
+
+    const img = document.querySelector('img:last-of-type');
+    if (img) {
+      console.log('Output:', img.outerHTML);
+      console.log('Title: ', img.getAttribute('title'));
+
+      const expected = 'uh "oh" > this should all be inside the title attribute';
+      expect(img.getAttribute('title')).to.equal(expected);
+    }
+  });
+
+  it('should handle JSON in data attributes with single quotes', () => {
+    const input = `<div data-json='{"key": "value"}'>Test</div>`;
+    console.log('Input: ', input);
+
+    writeAdHtml(input);
+
+    const div = document.querySelector('div[data-json]:last-of-type');
+    if (div) {
+      console.log('Output:', div.outerHTML);
+      console.log('Data:  ', div.getAttribute('data-json'));
+
+      const dataJson = div.getAttribute('data-json');
+      expect(dataJson).to.equal('{"key": "value"}');
+
+      const parsed = JSON.parse(dataJson);
+      expect(parsed.key).to.equal('value');
+    }
   });
 })


### PR DESCRIPTION
Closes [#1](https://github.com/postindustria-tech/prebid-universal-creative/issues/1)

| Initial | With Fix |
|------------|---------|
| ![Without Fix](https://github.com/user-attachments/assets/e6845c0b-9113-4769-b63f-4190d6b9be85) | ![With Fix](https://github.com/user-attachments/assets/5287c690-a85c-4874-8b56-cfbed8c57582) |
| ![Without Fix](https://github.com/user-attachments/assets/2fce693d-ed24-430f-bfb5-5cae7be87e1e) | ![With Fix](https://github.com/user-attachments/assets/486037d1-ce67-4d46-95d8-afc0d06b9dd3) |


