### PR TITLE
Update BrowserStack browser versions

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -1,39 +1,39 @@
 {
-  "bs_edge_latest_windows_10": {
+  "bs_edge_latest_windows_11": {
     "base": "BrowserStack",
-    "os_version": "10",
+    "os_version": "11",
     "browser": "edge",
     "browser_version": "latest",
     "device": null,
     "os": "Windows"
   },
-  "bs_chrome_latest_windows_10": {
+  "bs_chrome_latest_windows_11": {
     "base": "BrowserStack",
-    "os_version": "10",
+    "os_version": "11",
     "browser": "chrome",
     "browser_version": "latest",
     "device": null,
     "os": "Windows"
   },
-  "bs_chrome_87_windows_10": {
+  "bs_chrome_113_windows_10": {
     "base": "BrowserStack",
     "os_version": "10",
     "browser": "chrome",
-    "browser_version": "87.0",
+    "browser_version": "113.0",
     "device": null,
     "os": "Windows"
   },
-  "bs_firefox_latest_windows_10": {
+  "bs_firefox_latest_windows_11": {
     "base": "BrowserStack",
-    "os_version": "10",
+    "os_version": "11",
     "browser": "firefox",
     "browser_version": "latest",
     "device": null,
     "os": "Windows"
   },
-  "bs_safari_latest_mac_bigsur": {
+  "bs_safari_latest_mac": {
     "base": "BrowserStack",
-    "os_version": "Big Sur",
+    "os_version": "Sonoma",
     "browser": "safari",
     "browser_version": "latest",
     "device": null,
@@ -41,9 +41,9 @@
   },
   "bs_safari_15_catalina": {
     "base": "BrowserStack",
-    "os_version": "Catalina",
+    "os_version": "Monterey",
     "browser": "safari",
-    "browser_version": "13.1",
+    "browser_version": "15.6",
     "device": null,
     "os": "OS X"
   }


### PR DESCRIPTION
### Motivation
- Align the BrowserStack test matrix in `browsers.json` with the current `Prebid.js` matrix to keep test targets and OS/browser versions up to date.
- Replace older Windows and Safari targets and bump Chrome baseline so local BrowserStack jobs reflect supported browsers.

### Description
- Renamed `bs_edge_latest_windows_10` to `bs_edge_latest_windows_11` and set `os_version` to `11`.
- Renamed `bs_chrome_latest_windows_10` to `bs_chrome_latest_windows_11` and set `os_version` to `11` and renamed `bs_chrome_87_windows_10` to `bs_chrome_113_windows_10` with `browser_version` `113.0`.
- Renamed `bs_firefox_latest_windows_10` to `bs_firefox_latest_windows_11` and set `os_version` to `11`.
- Replaced `bs_safari_latest_mac_bigsur` with `bs_safari_latest_mac` using `os_version` `Sonoma`, and updated `bs_safari_15_catalina` to `os_version` `Monterey` with `browser_version` `15.6`.
- Updated the `browsers.json` file with these changes and committed the update.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('browsers.json','utf8')); console.log('valid json')"` which succeeded.
- Ran `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a288c7dcde8832bb8a714b09173279f)