### PR TITLE
Fix for Useless conditional

### DIFF
--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -443,7 +443,7 @@ describe('nativeAssetManager', () => {
       expect(win.document.body.innerHTML).to.not.include(`##hb_native_asset_id_4##`);
 
       // test that we are replacing ALL asset occurrences
-      expect(([...win.document.body.innerHTML.match(/new value/g)] || []).length, "expected 2 occurrences of \"new value\"").to.equal(2);
+      expect((win.document.body.innerHTML.match(/new value/g) || []).length, "expected 2 occurrences of \"new value\"").to.equal(2);
     });
 
     it('no placeholders found but requests all assets flag set - adTemplate', () => {


### PR DESCRIPTION
Use a null-safe match result before converting/counting. The best minimal fix is to apply the fallback to the `match()` result itself, not to the spread result.

In `test/spec/nativeAssetManager_spec.js`, update line 446:

- From: `([...win.document.body.innerHTML.match(/new value/g)] || []).length`
- To: `(win.document.body.innerHTML.match(/new value/g) || []).length`

This preserves existing functionality (counting occurrences) while making it safe when there are no matches and removing the always-true expression pattern. No imports, helper methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._