### PR TITLE
Remove duplicate static VAST gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -191,11 +191,6 @@ function buildUid() {
     .pipe(gulp.dest('dist'));
 }
 
-function includeStaticVastXmlFile() {
-  let target = gulp.src('static/prebid-mobile-rewarded-vast.xml');
-  return target.pipe(gulp.dest('dist'));
-}
-
 // Run the unit tests.
 //
 // By default, this runs in headless chrome.


### PR DESCRIPTION
### Motivation
- Resolve a CodeQL "Conflicting function declarations" alert by removing a duplicate function declaration.
- Simplify `gulpfile.js` to keep a single `includeStaticVastXmlFile` implementation and avoid confusion when tasks reference it.

### Description
- Deleted the duplicate `includeStaticVastXmlFile` function from `gulpfile.js` so only one implementation remains.
- Left all task arrays and `gulp.task` references unchanged so build behavior is preserved.

### Testing
- Ran `git diff --check` with no whitespace errors reported and it passed.
- Ran `npx gulp --tasks-simple` to validate task discovery and it listed tasks successfully.
- Ran `npx gulp build` and the build completed successfully in this environment.
- Ran `npm test`; Karma started but tests failed in this environment because `ChromeHeadless` binary is not available and `CHROME_BIN` is not set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28b36b54c0832b90feb11ded27af50)