### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -522,7 +522,7 @@ describe('nativeAssetManager', () => {
       let cb = sinon.spy();
       let targetingData = {
         uuid: '123'
-      }
+      };
 
       sinon.stub(utils, 'sendRequest').callsFake(function(arg1, cb) {
         let response = JSON.stringify({


### PR DESCRIPTION
Add an explicit semicolon at the end of the `targetingData` object assignment in `test/spec/nativeAssetManager_spec.js` (around lines 523–525).  
This is the minimal, behavior-preserving fix and aligns with the existing style in the enclosing function.

Specifically:
- Change:
  ```js
  let targetingData = {
    uuid: '123'
  }
  ```
- To:
  ```js
  let targetingData = {
    uuid: '123'
  };
  ```

No imports, helper methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._