### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -560,7 +560,7 @@ describe('nativeAssetManager', () => {
       // cta was not in the response so it should default to an empty string
       expect(win.document.body.innerHTML).to.include('<h1></h1>');
       expect(cb.getCall(0).args[0]).to.haveOwnProperty('eventtrackers');
-    })
+    });
   })
 
   describe('safe frame disabled', () => {


### PR DESCRIPTION
Use explicit semicolon termination for the `it(...)` statement on line 563 to match the enclosing code style and avoid ASI reliance.

Best single fix (no behavior change): in `test/spec/nativeAssetManager_spec.js`, change the closing of the test block from `})` to `});` at the end of the `"replace mobile native placeholder with their values"` test case.

No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._