### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/test/spec/renderingManager_spec.js
+++ b/test/spec/renderingManager_spec.js
@@ -126,7 +126,7 @@ describe('renderingManager', function() {
       };
       mockPrebidResponse(data);
       sinon.assert.calledWith(dynamic.runDynamicRenderer, data.adId, sinon.match(data))
-    })
+    });
 
     it("should render cross domain creative", function () {
       mockPrebidResponse({


### PR DESCRIPTION
Add the missing semicolon after the `it('should run renderer if present', ...)` block so the test statement ends with `});`, matching the dominant style in this file and satisfying the CodeQL rule.

Change needed:
- **File:** `test/spec/renderingManager_spec.js`
- **Region:** around lines 119–130
- Replace the closing `})` with `});`.

No imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._