### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -233,7 +233,7 @@ describe("renderingManager", function () {
         width: 400,
         height: 500,
       });
-    })
+    });
 
     it("should render amp creative", function () {
       ucTagData.hbPb = "10.00";


### PR DESCRIPTION
Use explicit semicolon termination for the `it('should send embed-resize message', ...)` statement by changing the closing `})` to `});` on line 236 in `test/spec/mobileAndAmpRender_spec.js`.

This is the minimal and best fix because it:
- resolves the CodeQL warning directly,
- keeps behavior unchanged,
- aligns with the prevailing semicolon style in the enclosing function and file,
- requires no imports, helper methods, or structural refactors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._