### PR TITLE
AMP resize test cleanup

### DIFF
--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -222,9 +222,10 @@ describe("renderingManager", function () {
       sandbox.restore();
     });
 
-    it('should send embed-resize message', () => {
+    it('should send AMP embed-size message without SafeFrame', () => {
+      expect(window.$sf).to.not.exist;
       sandbox.spy(window.parent, 'postMessage');
-      ucTagData.size = '400x500'
+      ucTagData.size = '400x500';
       renderAmpOrMobileAd(ucTagData);
       requests[0].respond(200, {}, JSON.stringify(response));
       sinon.assert.calledWith(window.parent.postMessage, {


### PR DESCRIPTION
Fixes #242, which was largely al ready fixed in #249 , by just adding a test

### Motivation
- Ensure AMP `embed-size` resize message continues to be sent even when SafeFrame is not present and prevent regressions related to issue #242 by adding explicit test coverage for the behavior already implemented in PR #249.

### Description
- Updated `test/spec/mobileAndAmpRender_spec.js` to replace the ambiguous embed-resize test with an explicit `should send AMP embed-size message without SafeFrame` test that asserts `window.parent.postMessage` is called with `{ sentinel: 'amp', type: 'embed-size', width, height }` and verifies `window.$sf` is not present.
- No production source changes were made; the behavior is already implemented in `src/mobileAndAmpRender.js` (AMP postMessage is sent outside the SafeFrame branch).

### Testing
- Ran `git` checks and grep to confirm the implementation and related PR `#249` are present (succeeded). 
- Attempted to run the unit test with `npm test -- --single-run --browsers ChromeHeadless --grep "AMP embed-size"`, but the run failed because ChromeHeadless binary is not available in this environment (`CHROME_BIN` unset), so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2920e96a30832baf97472ad8ec8898)