### PR TITLE
Upgrade core-js and core-js-pure to ^3.49.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
                 "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
                 "babel-plugin-transform-es3-property-literals": "^6.22.0",
                 "chai": "^4.1.2",
-                "core-js": "^3.13.0",
-                "core-js-pure": "^3.13.0",
+                "core-js": "^3.49.0",
+                "core-js-pure": "^3.49.0",
                 "del": "^5.0.0",
                 "execa": "^1.0.0",
                 "gulp": "^5.0.0",
@@ -4007,12 +4007,12 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.21.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-            "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
-            "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+            "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -4039,12 +4039,12 @@
             }
         },
         "node_modules/core-js-pure": {
-            "version": "3.21.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.1.tgz",
-            "integrity": "sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==",
-            "deprecated": "core-js-pure@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js-pure.",
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+            "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -17044,9 +17044,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "3.21.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-            "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+            "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
             "dev": true
         },
         "core-js-compat": {
@@ -17068,9 +17068,9 @@
             }
         },
         "core-js-pure": {
-            "version": "3.21.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.1.tgz",
-            "integrity": "sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==",
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+            "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
             "dev": true
         },
         "core-util-is": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
         "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
         "babel-plugin-transform-es3-property-literals": "^6.22.0",
         "chai": "^4.1.2",
-        "core-js": "^3.13.0",
-        "core-js-pure": "^3.13.0",
+        "core-js": "^3.49.0",
+        "core-js-pure": "^3.49.0",
         "del": "^5.0.0",
         "execa": "^1.0.0",
         "gulp": "^5.0.0",
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "babel-plugin-transform-object-assign": "^6.22.0",
-        "postscribe": "^2.0.8",
-        "gulp-cli": "^3.0.0"
+        "gulp-cli": "^3.0.0",
+        "postscribe": "^2.0.8"
     }
 }


### PR DESCRIPTION
### Motivation
- Remove use of outdated core-js releases and resolve deprecated warnings by upgrading to the current `3.49.0` line.
- Keep dev toolchain polyfills current to avoid performance and compatibility issues flagged by newer Node/V8 and security scanners.

### Description
- Bump `core-js` and `core-js-pure` devDependencies in `package.json` to `^3.49.0`.
- Refresh `package-lock.json` entries so resolved versions, `integrity` checksums, and metadata for `core-js@3.49.0` and `core-js-pure@3.49.0` are recorded.
- The project still shows a nested `core-js@2.6.12` pulled in by `babel-runtime`, which is unchanged by this update.

### Testing
- Ran `npm install` to update the lockfile and the install completed (npm reported 14 vulnerabilities to address separately). 
- Verified versions with `npm ls core-js core-js-pure`, which shows `core-js@3.49.0` and `core-js-pure@3.49.0` present. 
- Ran `npm run prepublish` (which runs `gulp build`) and the build succeeded. 
- Ran `npm test`, which failed in this environment because the ChromeHeadless binary is not available and `CHROME_BIN` is not set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2ad88cfc30832b9fa9921386413ab1)