### PR TITLE
Fix WebKit native click tracker integration test

### DIFF
--- a/integ-test/spec/native_legacy_spec.js
+++ b/integ-test/spec/native_legacy_spec.js
@@ -190,16 +190,11 @@ test.describe('Legacy native', () => {
                                         })
                                     })
 
-                                    test('should fire click trackers', async ({crossLocator, browserName}, testInfo) => {
-                                        if (browserName === 'webkit' && testInfo.project.use.headless !== false) {
-                                            // webkit does not like this test. It passes locally in headed mode:
-                                            //  $ npx run playwright test --headed --workers 1 --project webkit -g "should fire click trackers"
-                                            // but I am unable to get headed tests to work on the pipeline
-                                            // (e.g. https://app.circleci.com/pipelines/github/prebid/prebid-universal-creative/309/workflows/b9bafe18-e2b3-4081-a2f0-e74b33575b56/jobs/573)
-                                            return;
-                                        }
+                                    test('should fire click trackers', async ({crossLocator}) => {
                                         const el = await crossLocator('#the-ad .pb-click');
-                                        await el.click();
+                                        // Native click trackers are bound to pointerdown; dispatch the tracked event
+                                        // directly so headless WebKit does not flake on Playwright's synthetic click.
+                                        await el.dispatchEvent('pointerdown');
                                         await expect.poll(() => trackersFired.click).toBeTruthy();
                                     });
                                 });


### PR DESCRIPTION
fixes #256

### Motivation
- Address flakiness in the legacy native integration test on headless WebKit by exercising the actual event the native tracker listens for instead of relying on Playwright's synthetic `click`.

### Description
- Update `integ-test/spec/native_legacy_spec.js` to remove the WebKit-only early return and dispatch a `pointerdown` on the `.pb-click` element instead of calling `click`, with an explanatory comment.

### Testing
- Ran `git diff --check`, which succeeded. 
- Ran `npx playwright test --list --project webkit -g "should fire click trackers"`, which listed the targeted tests successfully. 
- Attempted `npx playwright test --project webkit -g "legacy response.*native proper.*template in creative.*safeframe.*should fire click trackers"`, which timed out because the ad never rendered in this environment due to external CDN/GPT requests returning `403`. 
- Ran `npm test` (`gulp test`), which failed in this environment because Karma could not find a `ChromeHeadless` binary (`CHROME_BIN` unset).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2aebc350bc832ba0cf5f6a9a128556)