### PR TITLE
Fix inefficient doctype cleanup regex

### DIFF
--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -6,6 +6,7 @@ export function writeAdHtml(markup, ps = postscribe) {
     markup = markup
         .replace(/<\?xml\b[^>]*(?:\?>|>)/gi, '')
         .replace(/<!doctype\b[^>\[]*(?:\[[^\]]*\][^>]*)?>/gi, '');
+
     let finalMarkup;
 
     try {

--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -3,7 +3,9 @@ import postscribe from 'postscribe';
 export function writeAdHtml(markup, ps = postscribe) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
-    markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[]+(\[[^\]]+)?))+[^>]+\>/gi, '');
+    markup = markup
+        .replace(/<\?xml\b[^>]*\?>/gi, '')
+        .replace(/<!doctype\b[^>\[]*(?:\[[^\]]*\][^>]*)?>/gi, '');
     ps(document.body, markup, {
         error: console.error
     });

--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -4,7 +4,7 @@ export function writeAdHtml(markup, ps = postscribe) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
     markup = markup
-        .replace(/<\?xml\b[^>]*\?>/gi, '')
+        .replace(/<\?xml\b[^>]*(?:\?>|>)/gi, '')
         .replace(/<!doctype\b[^>\[]*(?:\[[^\]]*\][^>]*)?>/gi, '');
     ps(document.body, markup, {
         error: console.error

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -249,6 +249,12 @@ describe('writeAdHtml', () => {
     sinon.assert.calledWith(ps, sinon.match.any, '<div>mock-ad</div>')
   });
 
+  it('removes malformed XML declarations from markup', () => {
+    const ps = sinon.stub();
+    writeAdHtml('<?xml version="1.0"><div>mock-ad</div>', ps);
+    sinon.assert.calledWith(ps, sinon.match.any, '<div>mock-ad</div>')
+  });
+
   it('removes doctype declarations with internal subsets from markup', () => {
     const ps = sinon.stub();
     writeAdHtml('<!DOCTYPE html [<!ENTITY nbsp "&#160;">]><div>mock-ad</div>', ps);

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -243,6 +243,18 @@ describe('writeAdHtml', () => {
     sinon.assert.calledWith(ps, sinon.match.any, '<div>mock-ad</div>')
   });
 
+  it('removes XML declarations from markup', () => {
+    const ps = sinon.stub();
+    writeAdHtml('<?xml version="1.0" encoding="UTF-8"?><div>mock-ad</div>', ps);
+    sinon.assert.calledWith(ps, sinon.match.any, '<div>mock-ad</div>')
+  });
+
+  it('removes doctype declarations with internal subsets from markup', () => {
+    const ps = sinon.stub();
+    writeAdHtml('<!DOCTYPE html [<!ENTITY nbsp "&#160;">]><div>mock-ad</div>', ps);
+    sinon.assert.calledWith(ps, sinon.match.any, '<div>mock-ad</div>')
+  });
+
   it('should execute script tag inserted into the body', () => {
     const markup = '<script>window.testScriptExecuted=true;</script>'
     writeAdHtml(markup);


### PR DESCRIPTION
### Motivation
- Prevent pathological/inefficient regex behavior when stripping XML/DOCTYPE markers from ad markup and ensure linear-time replacements. 
- Correctly remove XML declarations and DOCTYPEs that include internal subsets so injected markup is sanitized before `postscribe` insertion. 

### Description
- Replace the single complex combined regex in `src/postscribeRender.js` with two explicit replacements: `/<\?xml\b[^>]*\?>/gi` and `/<!doctype\b[^>\[]*(?:\[[^\]]*\][^>]*)?>/gi` to handle XML declarations and doctypes (including internal subsets). 
- Update `test/spec/mobileAndAmpRender_spec.js` to add test coverage for XML declarations and DOCTYPEs with internal subsets while keeping existing DOCTYPE and script-execution tests unchanged. 

### Testing
- Ran a focused Node check that exercises sample inputs against the new replacements and it passed for uppercase/lowercase DOCTYPE, XML declarations, and internal-subset DOCTYPEs. 
- Ran `git diff --check` to validate no whitespace/format issues and it passed. 
- Ran `npm test -- --single-run` which completed webpack bundling but the Karma run failed because `ChromeHeadless` binary is not available in this environment and `CHROME_BIN` is not set, so full test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a303a909dd0832bbbf9bb1b10175f31)