### PR TITLE
Fix postscribe markup normalization and tighten tests

### DIFF
--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -20,50 +20,13 @@ export function writeAdHtml(markup, ps = postscribe) {
 }
 
 /**
- * Normalizes an HTML string by parsing and re-serializing it,
- * returning the content between custom PUC_START and PUC_END markers.
+ * Normalizes an HTML string by parsing and re-serializing it.
  *
  * This function is specifically aimed at addressing an issue with `postscribe` where double quotes inside single-quoted
  * HTML attributes are not correctly escaped.
  */
 function normalizeMarkup(markup) {
-    const timestamp = Date.now();
-    const startMarkerId = `PUC_START_${timestamp}`;
-    const endMarkerId = `PUC_END_${timestamp}`;
-    const startMarker = `<div id="${startMarkerId}"></div>`;
-    const endMarker = `<div id="${endMarkerId}"></div>`;
-    const doc = new DOMParser().parseFromString(`${startMarker}${markup}${endMarker}`, "text/html");
-
-    const textMap = new Map();
-    let textId = 0;
-
-    const replaceTextNodes = (node) => {
-        if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
-            const id = `PUC_NODE_TEXT_${textId++}_${timestamp}`;
-            textMap.set(id, node.textContent);
-            const span = doc.createElement("span");
-            span.dataset.textId = id;
-            node.parentNode.replaceChild(span, node);
-        } else {
-            [...node.childNodes].forEach(replaceTextNodes);
-        }
-    };
-
-    let current = doc.querySelector(`#${startMarkerId}`).nextSibling;
-    const end = doc.querySelector(`#${endMarkerId}`);
-    while (current && current !== end) {
-        replaceTextNodes(current);
-        current = current.nextSibling;
-    }
-
-    const serialized = new XMLSerializer().serializeToString(doc);
-    const snippet = serialized
-        .split(startMarker)[1]
-        .split(endMarker)[0]
-        .replace(
-            /<span data-text-id="(PUC_NODE_TEXT_\d+_\d+)"[^>]*><\/span>/g,
-            (_, id) => textMap.get(id) || ""
-        );
-
-    return snippet.trim();
+    const template = document.createElement('template');
+    template.innerHTML = markup;
+    return template.innerHTML.trim();
 }

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -249,36 +249,24 @@ describe('writeAdHtml', () => {
 
   it('should handle single quotes with inner double quotes', () => {
     const input = `<img title='uh "oh" > this should all be inside the title attribute'>`;
-    console.log('Input: ', input);
 
     writeAdHtml(input);
 
     const img = document.querySelector('img:last-of-type');
-    if (img) {
-      console.log('Output:', img.outerHTML);
-      console.log('Title: ', img.getAttribute('title'));
-
-      const expected = 'uh "oh" > this should all be inside the title attribute';
-      expect(img.getAttribute('title')).to.equal(expected);
-    }
+    expect(img).to.exist;
+    expect(img.getAttribute('title')).to.equal('uh "oh" > this should all be inside the title attribute');
   });
 
   it('should handle JSON in data attributes with single quotes', () => {
     const input = `<div data-json='{"key": "value"}'>Test</div>`;
-    console.log('Input: ', input);
 
     writeAdHtml(input);
 
     const div = document.querySelector('div[data-json]:last-of-type');
-    if (div) {
-      console.log('Output:', div.outerHTML);
-      console.log('Data:  ', div.getAttribute('data-json'));
+    expect(div).to.exist;
 
-      const dataJson = div.getAttribute('data-json');
-      expect(dataJson).to.equal('{"key": "value"}');
-
-      const parsed = JSON.parse(dataJson);
-      expect(parsed.key).to.equal('value');
-    }
+    const dataJson = div.getAttribute('data-json');
+    expect(dataJson).to.equal('{"key": "value"}');
+    expect(JSON.parse(dataJson).key).to.equal('value');
   });
 })


### PR DESCRIPTION
### Motivation
- A regression caused by complex markup normalization broke handling of single-quoted attributes containing double quotes when passed through `postscribe`.
- The previous approach used marker wrappers, `XMLSerializer`, and text-node placeholders which was brittle and increased test instability.

### Description
- Replace the complex `normalizeMarkup` implementation in `src/postscribeRender.js` with a simpler parse/re-serialize using a DOM `template` (`template.innerHTML`) to preserve attribute contents.
- Preserve the safe fallback in `writeAdHtml` to use the original `markup` if normalization throws an error.
- Tighten regression tests in `test/spec/mobileAndAmpRender_spec.js` to assert element existence and exact attribute values instead of allowing silent passes, and remove debug logging.
- Changes touch `src/postscribeRender.js` and `test/spec/mobileAndAmpRender_spec.js` and aim to fix the single-quote/inner-double-quote parsing issue introduced earlier.

### Testing
- Ran `npx gulp lint` and it passed successfully.
- Ran `npx gulp build` and it completed successfully.
- Attempted `npm test -- --single-run` but it was blocked locally because no `ChromeHeadless` binary is available in this environment (Karma failure).
- Attempted `npx playwright install chromium` but it failed due to the Playwright CDN returning `403 Domain forbidden`, so browser-install-based integration tests were blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a454c32fe1c832bbc11b8504552f289)