### PR TITLE
Fix: Decode double-encoded HTML entities in `script/style` attributes

### DIFF
--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -58,20 +58,50 @@ function decodeHtmlAttribute(value) {
 }
 
 /**
- * Re-serializes the markup through the browser so postscribe receives
- * canonical HTML (double-quoted attributes, escaped entities, balanced tags).
- * postscribe mangles anything else, e.g. double quotes inside single-quoted
- * attribute values (https://github.com/prebid/prebid-universal-creative/pull/358).
+ * Normalizes an HTML string by parsing and re-serializing it,
+ * returning the content between custom PUC_START and PUC_END markers.
  *
- * The unique marker element switches the parser into <body> mode up front, so
- * the whole adm — including leading comments and scripts that would otherwise
- * be scattered into <head> or the document root — is parsed as body content,
- * matching how postscribe writes it into document.body. The marker is then
- * removed and the body serialized.
+ * This function is specifically aimed at addressing an issue with `postscribe` where double quotes inside single-quoted
+ * HTML attributes are not correctly escaped.
  */
 function normalizeMarkup(markup) {
-    const markerId = `PUC_MARKER_${Date.now()}`;
-    const doc = new DOMParser().parseFromString(`<div id="${markerId}"></div>${markup}`, 'text/html');
-    doc.getElementById(markerId).remove();
-    return doc.body.innerHTML.trim();
+    const timestamp = Date.now();
+    const startMarkerId = `PUC_START_${timestamp}`;
+    const endMarkerId = `PUC_END_${timestamp}`;
+    const startMarker = `<div id="${startMarkerId}"></div>`;
+    const endMarker = `<div id="${endMarkerId}"></div>`;
+    const doc = new DOMParser().parseFromString(`${startMarker}${markup}${endMarker}`, "text/html");
+
+    const textMap = new Map();
+    let textId = 0;
+
+    const replaceTextNodes = (node) => {
+        if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
+            const id = `PUC_NODE_TEXT_${textId++}_${timestamp}`;
+            textMap.set(id, node.textContent);
+            const span = doc.createElement("span");
+            span.dataset.textId = id;
+            node.parentNode.replaceChild(span, node);
+        } else {
+            [...node.childNodes].forEach(replaceTextNodes);
+        }
+    };
+
+    let current = doc.querySelector(`#${startMarkerId}`).nextSibling;
+    const end = doc.querySelector(`#${endMarkerId}`);
+    while (current && current !== end) {
+        replaceTextNodes(current);
+        current = current.nextSibling;
+    }
+
+    const serialized = new XMLSerializer().serializeToString(doc);
+    const snippet = serialized
+        .split(startMarker)[1]
+        .split(endMarker)[0]
+        .replace(
+            /<span data-text-id="(PUC_NODE_TEXT_\d+_\d+)"[^>]*><\/span>/g,
+            (_, id) => textMap.get(id) || ""
+        );
+
+    return snippet.trim();
 }

--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -15,55 +15,63 @@ export function writeAdHtml(markup, ps = postscribe) {
     }
 
     ps(document.body, finalMarkup, {
-        error: console.error
+        error: console.error,
+        beforeWriteToken: decodeEntitiesInMaterializedTokens
     });
 }
 
 /**
- * Normalizes an HTML string by parsing and re-serializing it,
- * returning the content between custom PUC_START and PUC_END markers.
+ * postscribe builds <script> and <style> elements by hand instead of writing
+ * them through the browser's HTML parser: see _buildScript/_buildStyle in
+ * postscribe's src/write-stream.js, which copy raw tokenizer output via
+ * el.setAttribute(name, value) and el.src = tok.src. Entities in their
+ * attributes are therefore never decoded — e.g. `src="...a=1&amp;b=2"` would
+ * be requested literally, breaking tracker URLs. Decode them here, as a
+ * browser would.
+ */
+function decodeEntitiesInMaterializedTokens(tok) {
+    const tagName = tok && tok.tagName && tok.tagName.toLowerCase();
+    if ((tagName === 'script' || tagName === 'style') && tok.attrs) {
+        Object.keys(tok.attrs).forEach((name) => {
+            if (typeof tok.attrs[name] === 'string' && tok.attrs[name].indexOf('&') !== -1) {
+                tok.attrs[name] = decodeHtmlAttribute(tok.attrs[name]);
+            }
+        });
+        // postscribe copies attrs.src to tok.src before this hook runs
+        if (typeof tok.src === 'string' && tok.src.indexOf('&') !== -1) {
+            tok.src = decodeHtmlAttribute(tok.src);
+        }
+    }
+    return tok;
+}
+
+/**
+ * Decodes HTML entities by round-tripping the value through a real parsed
+ * attribute. This matches browser rules for attributes exactly: `&amp;`
+ * becomes `&`, but semicolon-less references like `&notify=` stay literal.
+ */
+function decodeHtmlAttribute(value) {
+    const doc = new DOMParser().parseFromString(
+        `<i data-v="${value.replace(/"/g, '&quot;')}">`, 'text/html'
+    );
+    return doc.body.firstChild.getAttribute('data-v');
+}
+
+/**
+ * Re-serializes the markup through the browser so postscribe receives
+ * canonical HTML (double-quoted attributes, escaped entities, balanced tags).
+ * postscribe mangles anything else, e.g. double quotes inside single-quoted
+ * attribute values (https://github.com/prebid/prebid-universal-creative/pull/358).
  *
- * This function is specifically aimed at addressing an issue with `postscribe` where double quotes inside single-quoted
- * HTML attributes are not correctly escaped.
+ * The unique marker element switches the parser into <body> mode up front, so
+ * the whole adm — including leading comments and scripts that would otherwise
+ * be scattered into <head> or the document root — is parsed as body content,
+ * matching how postscribe writes it into document.body. The marker is then
+ * removed and the body serialized.
  */
 function normalizeMarkup(markup) {
-    const timestamp = Date.now();
-    const startMarkerId = `PUC_START_${timestamp}`;
-    const endMarkerId = `PUC_END_${timestamp}`;
-    const startMarker = `<div id="${startMarkerId}"></div>`;
-    const endMarker = `<div id="${endMarkerId}"></div>`;
-    const doc = new DOMParser().parseFromString(`${startMarker}${markup}${endMarker}`, "text/html");
-
-    const textMap = new Map();
-    let textId = 0;
-
-    const replaceTextNodes = (node) => {
-        if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
-            const id = `PUC_NODE_TEXT_${textId++}_${timestamp}`;
-            textMap.set(id, node.textContent);
-            const span = doc.createElement("span");
-            span.dataset.textId = id;
-            node.parentNode.replaceChild(span, node);
-        } else {
-            [...node.childNodes].forEach(replaceTextNodes);
-        }
-    };
-
-    let current = doc.querySelector(`#${startMarkerId}`).nextSibling;
-    const end = doc.querySelector(`#${endMarkerId}`);
-    while (current && current !== end) {
-        replaceTextNodes(current);
-        current = current.nextSibling;
-    }
-
-    const serialized = new XMLSerializer().serializeToString(doc);
-    const snippet = serialized
-        .split(startMarker)[1]
-        .split(endMarker)[0]
-        .replace(
-            /<span data-text-id="(PUC_NODE_TEXT_\d+_\d+)"[^>]*><\/span>/g,
-            (_, id) => textMap.get(id) || ""
-        );
-
-    return snippet.trim();
+    const markerId = `PUC_MARKER_${Date.now()}`;
+    const doc = new DOMParser().parseFromString(`<div id="${markerId}"></div>${markup}`, 'text/html');
+    doc.getElementById(markerId).remove();
+    return doc.body.innerHTML.trim();
 }

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -255,7 +255,7 @@ describe('writeAdHtml', () => {
 
     const img = document.querySelector('img:last-of-type');
     if (img) {
-      console.log('Output:', img.outerHTML);
+      console.log('Output: ', img.outerHTML);
       console.log('Title: ', img.getAttribute('title'));
 
       const expected = 'uh "oh" > this should all be inside the title attribute';

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -281,4 +281,100 @@ describe('writeAdHtml', () => {
       expect(parsed.key).to.equal('value');
     }
   });
+
+  // postscribe queues streams and blocks on pending external scripts, so
+  // output from a previous writeAdHtml call may be written asynchronously
+  function waitFor(condition, description) {
+    return new Promise((resolve, reject) => {
+      const started = Date.now();
+      (function poll() {
+        const result = condition();
+        if (result) {
+          resolve(result);
+        } else if (Date.now() - started > 5000) {
+          reject(new Error(`Timed out waiting for ${description}`));
+        } else {
+          setTimeout(poll, 10);
+        }
+      })();
+    });
+  }
+
+  function waitForScript(marker) {
+    return waitFor(
+      () => document.querySelector(`script[data-puc-test="${marker}"]`),
+      `script[data-puc-test="${marker}"]`
+    );
+  }
+
+  it('should not leave &amp; in a script src URL', () => {
+    const input = '<script data-puc-test="raw-amp" src="/base/test/fake-tracker?anId=8095&pubId=215421&bi=abc123"></script>';
+
+    writeAdHtml(input);
+
+    return waitForScript('raw-amp').then((script) => {
+      expect(script.getAttribute('src')).to.contain('anId=8095&pubId=215421&bi=abc123');
+      expect(script.getAttribute('src')).to.not.contain('&amp;');
+    });
+  });
+
+  it('should decode &amp; already present in the adm script src', () => {
+    const input = '<script data-puc-test="encoded-amp" src="/base/test/fake-tracker?a=1&amp;b=2"></script>';
+
+    writeAdHtml(input);
+
+    return waitForScript('encoded-amp').then((script) => {
+      expect(script.getAttribute('src')).to.contain('a=1&b=2');
+      expect(script.getAttribute('src')).to.not.contain('&amp;');
+    });
+  });
+
+  it('should not decode legacy semicolon-less entities in script src', () => {
+    const input = '<script data-puc-test="legacy-entities" src="/base/test/fake-tracker?x=1&notify=true&copy=2"></script>';
+
+    writeAdHtml(input);
+
+    return waitForScript('legacy-entities').then((script) => {
+      const src = script.getAttribute('src');
+      expect(src).to.contain('&notify=true');
+      expect(src).to.contain('&copy=2');
+      expect(src).to.not.contain('¬'); // ¬ from &not
+      expect(src).to.not.contain('©'); // © from &copy
+    });
+  });
+
+  it('should preserve the leading creative comment', () => {
+    const ps = sinon.stub();
+    const comment = '<!--Creative 123 served by Prebid.js Header Bidding-->';
+
+    writeAdHtml(`${comment}<div>ad</div>`, ps);
+
+    const written = ps.args[0][1];
+    expect(written.indexOf(comment)).to.equal(0);
+    expect(written).to.contain('<div>ad</div>');
+  });
+
+  it('should not corrupt inline script content containing && and <', () => {
+    const input = '<script>window.testInlineResult = (1 < 2) && "a&b";</script>';
+
+    writeAdHtml(input);
+
+    return waitFor(() => window.testInlineResult, 'inline script execution').then((result) => {
+      expect(result).to.equal('a&b');
+      window.testInlineResult = undefined;
+    });
+  });
+
+  it('should preserve text content with entities and ampersands', () => {
+    const input = '<div data-puc-test="text-content">Tom & Jerry &amp; friends</div>';
+
+    writeAdHtml(input);
+
+    return waitFor(
+      () => document.querySelector('div[data-puc-test="text-content"]'),
+      'text content div'
+    ).then((div) => {
+      expect(div.textContent).to.equal('Tom & Jerry & friends');
+    });
+  });
 })


### PR DESCRIPTION
# Description

PUC 1.18.0 addressed Postscribe’s mishandling of single-quoted HTML attributes by re-serializing the `adm` through `DOMParser` before rendering. The HTML serializer correctly escapes `&` as `&amp`, within attribute values. However, this exposed a latent issue in Postscribe that caused impression callbacks loaded via `<script src>` to break.

# Fix

Decode entities at the exact point postscribe diverges from browser behavior, using
postscribe's supported `beforeWriteToken` hook:

- For **script/style tokens only**, decode entities in all attributes and in
`tok.src` (postscribe copies `attrs.src` => `tok.src` before the hook runs, and
assigns `el.src = tok.src` when building the element).
- Static tokens are deliberately untouched - they're written through `innerHTML`
where entities must stay encoded for the browser to decode.
- Decoding round-trips the value through a real parsed attribute (`DOMParser`)
instead of string replacement, so it matches browser attribute-decoding rules
exactly: `&amp;` => `&`, while semicolon-less legacy references common in query
strings (`&notify=`, `&copy=`) stay literal, as they would in a real browser.

Also hardens `normalizeMarkup`: a marker element forces the parser into body mode so
leading comments (e.g. Prebid's `<!--Creative served by ...-->`) and head-bound
elements are preserved in order instead of being dropped or scattered into `<head>`.

<img width="2928" height="2211" alt="Screenshot 2026-08-05 at 15 05 14" src="https://github.com/user-attachments/assets/99ffb13b-7a83-4546-ae02-6698c9bf5a49" />
<img width="2625" height="2175" alt="Screenshot 2026-08-05 at 15 05 51" src="https://github.com/user-attachments/assets/ba915328-7f4c-49ee-a9b4-ff663082ec2b" />

