### PR TITLE
Revert fix: single quoted html attributes are incorrectly parsed by prescribe/postscribe

### DIFF
--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -7,65 +7,7 @@ export function writeAdHtml(markup, ps = postscribe) {
         .replace(/<\?xml\b[^>]*(?:\?>|>)/gi, '')
         .replace(/<!doctype\b[^>\[]*(?:\[[^\]]*\][^>]*)?>/gi, '');
 
-    let finalMarkup;
-
-    try {
-        finalMarkup = normalizeMarkup(markup);
-    } catch (error) {
-        console.error("Error normalizing markup:", error.message);
-        finalMarkup = markup;
-    }
-
-    ps(document.body, finalMarkup, {
+    ps(document.body, markup, {
         error: console.error
     });
-}
-
-/**
- * Normalizes an HTML string by parsing and re-serializing it,
- * returning the content between custom PUC_START and PUC_END markers.
- *
- * This function is specifically aimed at addressing an issue with `postscribe` where double quotes inside single-quoted
- * HTML attributes are not correctly escaped.
- */
-function normalizeMarkup(markup) {
-    const timestamp = Date.now();
-    const startMarkerId = `PUC_START_${timestamp}`;
-    const endMarkerId = `PUC_END_${timestamp}`;
-    const startMarker = `<div id="${startMarkerId}"></div>`;
-    const endMarker = `<div id="${endMarkerId}"></div>`;
-    const doc = new DOMParser().parseFromString(`${startMarker}${markup}${endMarker}`, "text/html");
-
-    const textMap = new Map();
-    let textId = 0;
-
-    const replaceTextNodes = (node) => {
-        if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
-            const id = `PUC_NODE_TEXT_${textId++}_${timestamp}`;
-            textMap.set(id, node.textContent);
-            const span = doc.createElement("span");
-            span.dataset.textId = id;
-            node.parentNode.replaceChild(span, node);
-        } else {
-            [...node.childNodes].forEach(replaceTextNodes);
-        }
-    };
-
-    let current = doc.querySelector(`#${startMarkerId}`).nextSibling;
-    const end = doc.querySelector(`#${endMarkerId}`);
-    while (current && current !== end) {
-        replaceTextNodes(current);
-        current = current.nextSibling;
-    }
-
-    const serialized = new XMLSerializer().serializeToString(doc);
-    const snippet = serialized
-        .split(startMarker)[1]
-        .split(endMarker)[0]
-        .replace(
-            /<span data-text-id="(PUC_NODE_TEXT_\d+_\d+)"[^>]*><\/span>/g,
-            (_, id) => textMap.get(id) || ""
-        );
-
-    return snippet.trim();
 }

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -2,7 +2,7 @@ import { renderAmpOrMobileAd } from 'src/mobileAndAmpRender';
 import * as postscribeRender from 'src/postscribeRender'
 import * as utils from 'src/utils';
 import { expect } from 'chai';
-import { writeAdHtml } from 'src/postscribeRender';
+import {writeAdHtml} from 'src/postscribeRender';
 
 
 describe("renderingManager", function () {
@@ -263,40 +263,5 @@ describe('writeAdHtml', () => {
     const markup = '<script>window.testScriptExecuted=true;</script>'
     writeAdHtml(markup);
     expect(window.testScriptExecuted).to.equal(true);
-  });
-
-  it('should handle single quotes with inner double quotes', () => {
-    const input = `<img title='uh "oh" > this should all be inside the title attribute'>`;
-    console.log('Input: ', input);
-
-    writeAdHtml(input);
-
-    const img = document.querySelector('img:last-of-type');
-    if (img) {
-      console.log('Output:', img.outerHTML);
-      console.log('Title: ', img.getAttribute('title'));
-
-      const expected = 'uh "oh" > this should all be inside the title attribute';
-      expect(img.getAttribute('title')).to.equal(expected);
-    }
-  });
-
-  it('should handle JSON in data attributes with single quotes', () => {
-    const input = `<div data-json='{"key": "value"}'>Test</div>`;
-    console.log('Input: ', input);
-
-    writeAdHtml(input);
-
-    const div = document.querySelector('div[data-json]:last-of-type');
-    if (div) {
-      console.log('Output:', div.outerHTML);
-      console.log('Data:  ', div.getAttribute('data-json'));
-
-      const dataJson = div.getAttribute('data-json');
-      expect(dataJson).to.equal('{"key": "value"}');
-
-      const parsed = JSON.parse(dataJson);
-      expect(parsed.key).to.equal('value');
-    }
   });
 })


### PR DESCRIPTION
This reverts commit 8bded7e94cbadcb1580e5cb4c919ee73569e9451 due to a double URL-encoding issue, with the goal of stabilizing the PUC.